### PR TITLE
Update the version of Helm charts automatically

### DIFF
--- a/.ci/find_docker_tag.py
+++ b/.ci/find_docker_tag.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Python script to find Docker image tag from YugabyteDB release version"""
+from optparse import OptionParser
+from re import match
+from requests import request
+from sys import exit
+
+DOCKER_TAGS_URL = "https://registry.hub.docker.com/v1/repositories/yugabytedb/yugabyte/tags"
+
+
+def main(release):
+    """Use YugabyteDB release version to find respective docker image tag"""
+    if not match("[0-9]+.[0-9]+.[0-9]+.[0-9]+", release.version):
+        exit("Version validation failed: required format: *.*.*.*")
+
+    response = request(method='GET', url=DOCKER_TAGS_URL)
+    if not response.ok:
+        exit("Got {} from {}.".format(response.status_code, DOCKER_TAGS_URL))
+    json_response = response.json()
+
+    tags = dict()
+    for tag_obj in json_response:
+        tag = tag_obj['name']
+        if tag.startswith(release.version):
+            build_number = int(tag[tag.rindex("-b")+2:])
+            tags[build_number] = tag
+    if not tags:
+        exit("Given version did not match any of the tags")
+
+    latest_build = max(tags.keys())
+    print(tags[latest_build])
+
+
+if __name__ == "__main__":
+    usage = "usage: %prog [options] -r <release-version>"
+    parser = OptionParser(usage)
+    parser.add_option("-r", "--release", type="string", dest="version")
+
+    (ARGS, OPTIONS) = parser.parse_args()
+
+    for option in ARGS.__dict__:
+        if ARGS.__dict__[option] is None:
+            parser.error("failed to parse the arguments.")
+    main(ARGS)

--- a/.ci/update_version.sh
+++ b/.ci/update_version.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# version_gt compares the given two versions.
+# It returns 0 exit code if the version1 is greater than version2.
+# https://web.archive.org/web/20191003081436/http://ask.xmodulo.com/compare-two-version-numbers.html
+function version_gt() {
+  test "$(echo -e "$1\n$2" | sort -V | head -n 1)" != "$1"
+}
+
+
+if [[ $# -ne 1 ]]; then
+  echo "No arguments supplied. Please provide the release version" 1>&2
+  echo "Terminating the script execution." 1>&2
+  exit 1
+fi
+
+release_version="$1"
+# Version mentioned in Charts.yaml
+current_version="$(grep -r "^version" "stable/yugabyte/Chart.yaml" | awk '{ print $2 }')"
+if ! version_gt "${release_version%.*}" "${current_version}" ; then
+  echo "Release version is either older or equal to the current version: '${release_version%.*}' <= '${current_version}'" 1>&2
+  exit 1
+fi
+
+# Find Docker image tag respective to YugabyteDB release version
+docker_image_tag_regex=[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+-b[0-9]\+
+docker_image_tag="$(python3 ".ci/find_docker_tag.py" "-r" "${release_version}")"
+if [[ "${docker_image_tag}" =~ ${docker_image_tag_regex} ]]; then
+  echo "Latest Docker image tag for '${release_version}': '${docker_image_tag}'."
+else
+  echo "Failed to parse the Docker image tag: '${docker_image_tag}'" 1>&2
+  exit 1
+fi
+
+# Following parameters will be updated in the below-mentioned files:
+#  1. ./stable/yugabyte/Chart.yaml	 -   version, appVersion
+#  2. ./stable/yugabyte/values.yaml	 -   tag
+#  3. ./stable/yugaware/Chart.yaml	 -   version, appVersion
+#  4. ./stable/yugaware/values.yaml	 -   tag
+#  5. ./stable/yugabyte/app-readme.md	 -   *.*.*.*-b*
+
+files_to_update_version=("stable/yugabyte/Chart.yaml" "stable/yugaware/Chart.yaml")
+files_to_update_tag=("stable/yugabyte/values.yaml" "stable/yugaware/values.yaml")
+chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"
+
+# Update appVersion and version in Chart.yaml
+for file in "${files_to_update_version[@]}"; do
+  echo "Updating file: '${file}' with version: '${chart_release_version}', appVersion: '${docker_image_tag}'"
+  sed -i "s/^version: .*/version: ${chart_release_version}/g" "${file}"
+  sed -i "s/^appVersion: .*/appVersion: ${docker_image_tag}/g" "${file}"
+done
+
+# Update tag in values.yaml
+for file in "${files_to_update_tag[@]}"; do
+  echo "Updating file: '${file}' with tag: '${docker_image_tag}'"
+  sed -i "s/^  tag: .*/  tag: ${docker_image_tag}/g" "${file}"
+done
+
+# Update version number in stable/yugabyte/app-readme.md
+echo "Updating file: 'stable/yugabyte/app-readme.md' with version: '${docker_image_tag}'"
+sed -i "s/[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+-b[0-9]\+/${docker_image_tag}/g" "stable/yugabyte/app-readme.md"

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,0 +1,56 @@
+name: "Update YugabyteDB version"
+on:
+  repository_dispatch:
+    types:
+    - update-on-release
+jobs:
+  update-version:
+    if: github.event.client_payload.prerelease == 'false'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Configure git"
+      run: |
+        git config user.name 'YugaByte CI'
+        git config user.email 'yugabyte-ci@users.noreply.github.com'
+    - name: "Extract version number from tag"
+      id: extract-version
+      run: |
+        tag_name="${{ github.event.client_payload.release }}"
+        echo "Extracting version number from the tag '${tag_name}'."
+        version_number="${tag_name/v/}"
+        # Keep dots and count the string length
+        dot_count="$(res="${version_number//[^.]/}"; echo "${#res}")"
+        if [[ "${dot_count}" -eq 2 ]]; then
+          version_number="${version_number}.0"
+        fi
+        if [[ "$(res="${version_number//[^.]/}"; echo "${#res}")" -ne 3 ]]; then
+          echo "The tag '${tag_name}' is invalid. Expected format: 'v1.2.3' or 'v1.2.3.5'." 1>&2
+          exit 1
+        fi
+        echo "Extracted the version number '${version_number}'."
+        echo "::set-output name=yb_version::${version_number}"
+    - name: "Check python version and install dependencies"
+      run: |
+        python3 --version
+        pip3 install requests
+    - name: "Update the version"
+      id: update-version
+      continue-on-error: true
+      run: |
+        .ci/update_version.sh '${{steps.extract-version.outputs.yb_version}}'
+    - name: "Push the changes"
+      if: steps.update-version.outcome == 'success'
+      run: |
+        git status
+        git diff
+        git add ./stable/yugabyte/Chart.yaml ./stable/yugaware/Chart.yaml \
+                ./stable/yugabyte/values.yaml ./stable/yugaware/values.yaml ./stable/yugabyte/app-readme.md
+        git commit -m "Update the version to ${{steps.extract-version.outputs.yb_version}}"
+        git push origin ${{ github.ref }}
+    - name: "Show git status in case of failure"
+      if: steps.update-version.outcome == 'failure'
+      run: |
+        git status
+        git diff
+        exit 1


### PR DESCRIPTION
- Modifies the charts stable/yugabyte and stable/yugaware.
- Updates the version from Chart.yaml as well as sets the correct tag
  in values.yaml.
- Uses Docker registry's API to fetch the latest tag for released
  version.
- https://registry.hub.docker.com/v1/repositories/yugabytedb/yugabyte/tags

Fixes https://github.com/yugabyte/yugabyte-db/issues/4261
ref: https://github.com/yugabyte/yugabyte-db/issues/3936