### PR TITLE
[stable/yugabyte] set workingDir to /mnt/disk0

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -246,6 +246,11 @@ spec:
         {{ else }}
 {{ toYaml $root.Values.resource.tserver | indent 10 }}
         {{ end }}
+        # core dumps are collected to workingDir if
+        # kernel.core_pattern is set to a relative path like
+        # core.%e.%p.%t ref:
+        # https://github.com/yugabyte/charts/issues/11
+        workingDir: "/mnt/disk0"
         command:
         {{ if eq .name "yb-masters" }}
           - "/home/yugabyte/bin/yb-master"


### PR DESCRIPTION
- If host has kernel.core_pattern set to some relative path like `core.%e.%p.%t`, then the core dumps will get saved in the volume mounted at `/mnt/disk0`

**Note**: after this change, `kubectl exec …` commands will have to use absolute paths to binaries from bin directory, i.e. `/home/yugabyte/bin/ysqlsh` instead of `bin/ysqlsh`.

### Scenarios tested
- Installation with `storage.ephemeral=true` and `storage.ephemeral=false`
- Installation with `tls.enabled=true` and `tls.enabled=false`

### How to check if workingDir is set correctly
- Output of given commands should match
  ```console
  $ kubectl exec -it yb-master-1 -nyb-chart -- bash
  [root@yb-master-1 disk0]# pwd
  /mnt/disk0
  ```

Fixes #11 