### PR TITLE
[stable/yugabyte] add ServiceMonitor for yb-master and yb-tserver

### DIFF
--- a/stable/yugabyte/templates/master-servicemonitor.yaml
+++ b/stable/yugabyte/templates/master-servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.serviceMonitor.enabled .Values.serviceMonitor.master.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "yugabyte.fullname" . }}-yb-master
+  labels:
+    app: "yb-master"
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    component: "{{ .Values.Component }}"
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: "release"
+  selector:
+    matchLabels:
+      app: "yb-master"
+      release: {{ .Release.Name | quote }}
+      service-type: "headless"
+  endpoints:
+
+  {{- with .Values.serviceMonitor.master }}
+  {{- if .enabled }}
+  - port: {{ .port }}
+    path: {{ .path }}
+    {{- if .interval }}
+    interval: {{ .interval }}
+    {{- else }}
+    interval: {{ $.Values.serviceMonitor.interval }}
+    {{- end }}
+    relabelings:
+    - targetLabel: "group"
+      replacement: "yb-master"
+    - targetLabel: "export_type"
+      replacement: "master_export"
+    - targetLabel: "node_prefix"
+      replacement: {{ $.Release.Name | quote }}
+    metricRelabelings:
+    {{- toYaml $.Values.serviceMonitor.commonMetricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -64,6 +64,7 @@ metadata:
     release: {{ $root.Release.Name | quote }}
     chart: "{{ $root.Chart.Name }}"
     component: "{{ $root.Values.Component }}"
+    service-type: "headless"
 spec:
   clusterIP: None
   ports:

--- a/stable/yugabyte/templates/tserver-servicemonitor.yaml
+++ b/stable/yugabyte/templates/tserver-servicemonitor.yaml
@@ -1,0 +1,107 @@
+{{- $sm := .Values.serviceMonitor }}
+{{ if and $sm.enabled (or $sm.tserver.enabled $sm.ycql.enabled $sm.ysql.enabled $sm.yedis.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "yugabyte.fullname" . }}-yb-tserver
+  labels:
+    app: "yb-tserver"
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    component: "{{ .Values.Component }}"
+    {{- with .Values.serviceMonitor.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: "release"
+  selector:
+    matchLabels:
+      app: "yb-tserver"
+      release: {{ .Release.Name | quote }}
+      service-type: "headless"
+  endpoints:
+
+  {{- with .Values.serviceMonitor.tserver }}
+  {{- if .enabled }}
+  - port: {{ .port }}
+    path: {{ .path }}
+    {{- if .interval }}
+    interval: {{ .interval }}
+    {{- else }}
+    interval: {{ $.Values.serviceMonitor.interval }}
+    {{- end }}
+    relabelings:
+    - targetLabel: "group"
+      replacement: "yb-tserver"
+    - targetLabel: "export_type"
+      replacement: "tserver_export"
+    - targetLabel: "node_prefix"
+      replacement: {{ $.Release.Name | quote }}
+    metricRelabelings:
+    {{- toYaml $.Values.serviceMonitor.commonMetricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
+  {{- with .Values.serviceMonitor.ycql }}
+  {{- if .enabled }}
+  - port: {{ .port }}
+    path: {{ .path }}
+    {{- if .interval }}
+    interval: {{ .interval }}
+    {{- else }}
+    interval: {{ $.Values.serviceMonitor.interval }}
+    {{- end }}
+    relabelings:
+    - targetLabel: "group"
+      replacement: "ycql"
+    - targetLabel: "export_type"
+      replacement: "cql_export"
+    - targetLabel: "node_prefix"
+      replacement: {{ $.Release.Name | quote }}
+    metricRelabelings:
+    {{- toYaml $.Values.serviceMonitor.commonMetricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
+  {{- with .Values.serviceMonitor.ysql }}
+  {{- if .enabled }}
+  - port: {{ .port }}
+    path: {{ .path }}
+    {{- if .interval }}
+    interval: {{ .interval }}
+    {{- else }}
+    interval: {{ $.Values.serviceMonitor.interval }}
+    {{- end }}
+    relabelings:
+    - targetLabel: "group"
+      replacement: "ysql"
+    - targetLabel: "export_type"
+      replacement: "ysql_export"
+    - targetLabel: "node_prefix"
+      replacement: {{ $.Release.Name | quote }}
+    metricRelabelings:
+    {{- toYaml $.Values.serviceMonitor.commonMetricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}
+
+  {{- with .Values.serviceMonitor.yedis }}
+  {{- if .enabled }}
+  - port: {{ .port }}
+    path: {{ .path }}
+    {{- if .interval }}
+    interval: {{ .interval }}
+    {{- else }}
+    interval: {{ $.Values.serviceMonitor.interval }}
+    {{- end }}
+    relabelings:
+    - targetLabel: "group"
+      replacement: "yedis"
+    - targetLabel: "export_type"
+      replacement: "redis_export"
+    - targetLabel: "node_prefix"
+      replacement: {{ $.Release.Name | quote }}
+    metricRelabelings:
+    {{- toYaml $.Values.serviceMonitor.commonMetricRelabelings | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -93,6 +93,77 @@ Services:
       yql-port: "9042"
       yedis-port: "6379"
       ysql-port: "5433"
+      ycql-metrics: "12000"
+      yedis-metrics: "11000"
+      ysql-metrics: "13000"
+
+
+serviceMonitor:
+  ## If true, two ServiceMonitor CRs are created. One for yb-master
+  ## and one for yb-tserver
+  ## https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor
+  ##
+  enabled: false
+  ## interval is the default scrape_interval for all the endpoints
+  interval: 30s
+  ## extraLabels can be used to add labels to the ServiceMonitors
+  ## being created
+  extraLabels: {}
+    # release: prom
+
+  ## Configurations of ServiceMonitor for yb-master
+  master:
+    enabled: true
+    port: "ui"
+    interval: ""
+    path: "/prometheus-metrics"
+
+  ## Configurations of ServiceMonitor for yb-tserver
+  tserver:
+    enabled: true
+    port: "ui"
+    interval: ""
+    path: "/prometheus-metrics"
+  ycql:
+    enabled: true
+    port: "ycql-metrics"
+    interval: ""
+    path: "/prometheus-metrics"
+  ysql:
+    enabled: true
+    port: "ysql-metrics"
+    interval: ""
+    path: "/prometheus-metrics"
+  yedis:
+    enabled: true
+    port: "yedis-metrics"
+    interval: ""
+    path: "/prometheus-metrics"
+
+  commonMetricRelabelings:
+  # https://git.io/JJW5p
+  # Save the name of the metric so we can group_by since we cannot by __name__ directly...
+  - sourceLabels: ["__name__"]
+    regex: "(.*)"
+    targetLabel: "saved_name"
+    replacement: "$1"
+  # The following basically retrofit the handler_latency_* metrics to label format.
+  - sourceLabels: ["__name__"]
+    regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(.*)"
+    targetLabel: "server_type"
+    replacement: "$1"
+  - sourceLabels: ["__name__"]
+    regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(.*)"
+    targetLabel: "service_type"
+    replacement: "$2"
+  - sourceLabels: ["__name__"]
+    regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(_sum|_count)?"
+    targetLabel: "service_method"
+    replacement: "$3"
+  - sourceLabels: ["__name__"]
+    regex: "handler_latency_(yb_[^_]*)_([^_]*)_([^_]*)(_sum|_count)?"
+    targetLabel: "__name__"
+    replacement: "rpc_latency$4"
 
 resources: {}
 


### PR DESCRIPTION
- ref: https://docs.yugabyte.com/latest/explore/observability/linux/
- Creates two ServiceMonitors, one for yb-master and one for
  yb-tserver.
- Adds new endpoints for ycql, ysql and yedis metrics (11000, 12000 &
  13000).
- Adds new label `service-type: headless` to the headless services of
  yb-master and yb-tserver. This makes sure that we just select one
  service through labelSelector of ServiceMonitor.
- Sets the job and node_prefix label to release name of the chart as
  one release represents one cluster.

Ref: #7 

## Test plan
- Install Prometheus Operator chart,
  ```sh
  $ kubectl create ns monitoring 
  $ helm3 install prom -n monitoring stable/prometheus-operator
  ```
- Install the stable/yugabyte chart from the clone,
  ```sh
  $ kubectl create ns yb-chart
  $ helm3 install ybtest -n yb-chart ./stable/yugabyte/ \
       --set replicas.master=1 \
       --set replicas.tserver=1 \
       --set serviceMonitor.enabled=true \
       --set serviceMonitor.extraLabels.release=prom
  ```
- Port forward to the Prometheus instance and visit http://localhost:9090/targets (it should have targets like shown below)
  ```sh
  $ kubectl port-forward prometheus-prom-prometheus-operator-prometheus-0 -nmonitoring 9090
  ```
  ![Prometheus /targets UI](https://user-images.githubusercontent.com/5154532/88019503-9324cb00-cb47-11ea-99d8-2acd68c6c73c.png)
