### PR TITLE
[YW] Add CSRF play filters config to application.conf

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -69,6 +69,26 @@ data:
       health.ses_email_password = "{{ .Values.yugaware.health.password }}"
     }
 
+    play.filters {
+      # CSRF config
+      csrf {
+        cookie {
+          # If non null, the CSRF token will be placed in a cookie with this name
+          name = "csrfCookie"
+          # Whether the cookie should be set to secure
+          secure = false
+          # Whether the cookie should have the HTTP only flag set
+          httpOnly = false
+        }
+        # Whether to bypass CSRF check if CORS check is satisfied
+        bypassCorsTrustedOrigins = false
+        header {
+          # The name of the header to accept CSRF tokens from.
+          name = "Csrf-Token"
+        }
+      }
+    }
+
 {{- if .Values.tls.enabled }}
 ---
 apiVersion: v1


### PR DESCRIPTION
Add the application.conf entries specified in this commit - https://github.com/yugabyte/yugabyte-db/commit/fdcb32ecfdfe17fca5e5749340a7167424c75970 - to the helm config for YW.

The play.http.secret.key part is not included here so that we don't break (older patch YW + latest helm chart) packaging. play.crypto.key is apparently deprecated but still works.

Test Plan:

1. I tested this chart with an older YW build 2.2.2.0-b15 and verified that I was able to register, create a new user, login etc.
2. I tested this chart with the latest YW build 2.3.0.0-b149 - I could not verify that this config change actually works. We still have CSRF issues that should be fixed in the next build after https://github.com/yugabyte/yugabyte-db/commit/5bc4d7c92ec8f650b98e402227c3097ce5a2bae3 