### PR TITLE
Initial changes for compatibility with Istio

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -260,7 +260,11 @@ spec:
           {{ else }}
           - "--fs_data_dirs=/var/yugabyte"
           {{- end }}
+          {{- if $root.Values.istioCompatibility.enabled }}
+          - "--rpc_bind_addresses=0.0.0.0:7100"
+          {{- else }}
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          {{- end }}
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:7100"
           - "--webserver_interface=0.0.0.0"
           {{ if $root.Values.isMultiAz }}
@@ -292,8 +296,16 @@ spec:
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:9100"
+          {{- if $root.Values.istioCompatibility.enabled }}
+          - "--rpc_bind_addresses=0.0.0.0:9100"
+          {{- else }}
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          {{- end }}
+          {{- if $root.Values.istioCompatibility.enabled }}
+          - "--cql_proxy_bind_address=0.0.0.0:9042"
+          {{- else }}
           - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          {{- end }}
           - "--webserver_interface=0.0.0.0"
           {{ if not $root.Values.disableYsql }}
           - "--enable_ysql=true"

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -262,6 +262,7 @@ spec:
           {{- end }}
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:7100"
+          - "--webserver_interface=0.0.0.0"
           {{ if $root.Values.isMultiAz }}
           - "--master_addresses={{ $root.Values.masterAddresses}}"
           - "--replication_factor={{ $root.Values.replicas.totalMasters }}"
@@ -293,6 +294,7 @@ spec:
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:9100"
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          - "--webserver_interface=0.0.0.0"
           {{ if not $root.Values.disableYsql }}
           - "--enable_ysql=true"
           - "--pgsql_proxy_bind_address=0.0.0.0:5433"

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -100,6 +100,12 @@ Services:
       http-yedis-met: "11000"
       http-ysql-met: "13000"
 
+## Should be set to true only if Istio is being used.
+## TODO: remove this once
+## https://github.com/yugabyte/yugabyte-db/issues/5641 is fixed.
+##
+istioCompatibility:
+  enabled: false
 
 serviceMonitor:
   ## If true, two ServiceMonitor CRs are created. One for yb-master

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -70,35 +70,35 @@ serviceEndpoints:
     type: LoadBalancer
     app: "yb-master"
     ports:
-      ui: "7000"
+      http-ui: "7000"
 
   - name: "yb-tserver-service"
     type: LoadBalancer
     app: "yb-tserver"
     ports:
-      yql-port: "9042"
-      yedis-port: "6379"
-      ysql-port: "5433"
+      tcp-yql-port: "9042"
+      tcp-yedis-port: "6379"
+      tcp-ysql-port: "5433"
 
 Services:
   - name: "yb-masters"
     label: "yb-master"
     memory_limit_to_ram_ratio: 0.85
     ports:
-      ui: "7000"
-      rpc-port: "7100"
+      http-ui: "7000"
+      tcp-rpc-port: "7100"
 
   - name: "yb-tservers"
     label: "yb-tserver"
     ports:
-      ui: "9000"
-      rpc-port: "7100"
-      yql-port: "9042"
-      yedis-port: "6379"
-      ysql-port: "5433"
-      ycql-metrics: "12000"
-      yedis-metrics: "11000"
-      ysql-metrics: "13000"
+      http-ui: "9000"
+      tcp-rpc-port: "9100"
+      tcp-yql-port: "9042"
+      tcp-yedis-port: "6379"
+      tcp-ysql-port: "5433"
+      http-ycql-met: "12000"
+      http-yedis-met: "11000"
+      http-ysql-met: "13000"
 
 
 serviceMonitor:
@@ -117,29 +117,29 @@ serviceMonitor:
   ## Configurations of ServiceMonitor for yb-master
   master:
     enabled: true
-    port: "ui"
+    port: "http-ui"
     interval: ""
     path: "/prometheus-metrics"
 
   ## Configurations of ServiceMonitor for yb-tserver
   tserver:
     enabled: true
-    port: "ui"
+    port: "http-ui"
     interval: ""
     path: "/prometheus-metrics"
   ycql:
     enabled: true
-    port: "ycql-metrics"
+    port: "http-ycql-met"
     interval: ""
     path: "/prometheus-metrics"
   ysql:
     enabled: true
-    port: "ysql-metrics"
+    port: "http-ysql-met"
     interval: ""
     path: "/prometheus-metrics"
   yedis:
     enabled: true
-    port: "yedis-metrics"
+    port: "http-yedis-met"
     interval: ""
     path: "/prometheus-metrics"
 


### PR DESCRIPTION
-   Prefix the port names with correct protocol
    -   This enables correct protocol selection when using Istio <https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/>
-   ~~Add ability to override rpc_bind_addresses & cql_proxy_bind_address~~
    -   ~~This adds new keys `master` and `tserver` to the values.yaml. This is because we cannot override specific part of a list item i.e. one cannot override only `Services[0].name`, they will have to write the whole list item again.~~
-   Set --webserver_interface explicitly to 0.0.0.0
-   Add istioCompatibility setting to values
    -   This changes the rpc_bind_addresses to 0.0.0.0 along with their respective ports when istioCompatibility.enabled is set to true.

To use yugabyte chart with Istio, one will have to use following in their values file,

```yaml
istioCompatibility:
  enabled: true
```

### Scenarios tested

Following is the list of things tested against normal Helm chart deployment, Helm chart with TLS, Istio with Helm chart and Istio mTLS with Helm chart.

-   Normal cluster formation
    -   Check the UI (port-forward, Service IP)
    -   Run some yb-admin commands.
        
        ```bash
        export master_address_test="yb-master-0.yb-masters.yb-demo.svc.cluster.local:7100,yb-master-1.yb-masters.yb-demo.svc.cluster.local:7100,yb-master-2.yb-masters.yb-demo.svc.cluster.local:7100"
        kubectl exec -it -n yb-demo yb-master-0 -- /home/yugabyte/master/bin/yb-admin --master_addresses ${master_address_test} list_all_tablet_servers
        # for TLS enabled cluster
        kubectl exec -it -n yb-demo yb-master-0 -- /home/yugabyte/master/bin/yb-admin --master_addresses ${master_address_test} list_all_tablet_servers --certs_dir_name /opt/certs/yugabyte/
        ```
    -   Check all the webserver UIs of yb-master and yb-tserver.
        
        ```bash
        curl http://yb-tserver-0.yb-tservers.yb-demo.svc.cluster.local:9000
        curl http://yb-tserver-0.yb-tservers.yb-demo.svc.cluster.local:11000/prometheus-metrics
        curl http://yb-tserver-0.yb-tservers.yb-demo.svc.cluster.local:12000/prometheus-metrics
        curl http://yb-tserver-0.yb-tservers.yb-demo.svc.cluster.local:13000/prometheus-metrics
        ```
-   YSQL related things
    -   Check if SQL operations work from, TServer specific DNS as well as service DNS.
        
        ```bash
        kubectl run yb-client -it --rm  --image yugabytedb/yugabyte-client --command -- bash
        #
        ysqlsh -h yb-tserver-0.yb-tservers.yb-demo.svc.cluster.local # "sslmode=require"
        CREATE TABLE test1(id int primary key); INSERT INTO test1 SELECT * FROM generate_series(1,10); SELECT * FROM test1;
        #
        ysqlsh -h yb-tservers.yb-demo.svc.cluster.local # "sslmode=require"
        CREATE TABLE test2(id int primary key); INSERT INTO test2 SELECT * FROM generate_series(1,10); SELECT * FROM test2;
        #
        ysqlsh -h yb-tserver-service.yb-demo.svc.cluster.local # "sslmode=require"
        CREATE TABLE test3(id int primary key); INSERT INTO test3 SELECT * FROM generate_series(1,10); SELECT * FROM test3;
        ```
-   YCQL related things
    -   Check if CQL operations work from, TServer specific DNS as well as service DNS.
        
        ```bash
        kubectl run yb-client -it --rm  --image yugabytedb/yugabyte-client --command -- bash
        #
        ycqlsh yb-tserver-0.yb-tservers.yb-demo.svc.cluster.local # --ssl
        create keyspace test1; create table test1.bar(id int primary key); insert into test1.bar (id) values (1); select * from test1.bar;
        #
        ycqlsh yb-tservers.yb-demo.svc.cluster.local # --ssl
        create keyspace test2; create table test2.bar(id int primary key); insert into test2.bar (id) values (1); select * from test2.bar;
        #
        ycqlsh yb-tserver-service.yb-demo.svc.cluster.local # --ssl
        create keyspace test3; create table test3.bar(id int primary key); insert into test3.bar (id) values (1); select * from test3.bar;
        ```

Closes <https://github.com/yugabyte/yugabyte-db/issues/5584>
Ref: <https://github.com/yugabyte/yugabyte-db/issues/2158>
Ref: <https://github.com/yugabyte/yugabyte-db/issues/5641>