### PR TITLE
Add ip_version_support setting to set flags for IPv6

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -266,7 +266,10 @@ spec:
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           {{- end }}
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:7100"
-          - "--webserver_interface=0.0.0.0"
+          - "--webserver_interface={{ eq $root.Values.ip_version_support "v6_only" | ternary "[::]" "0.0.0.0" }}"
+          {{ if eq $root.Values.ip_version_support "v6_only"}}
+          - "--net_address_filter=ipv6_external,ipv6_non_link_local,ipv6_all,ipv4_external,ipv4_all"
+          {{ end }}
           {{ if $root.Values.isMultiAz }}
           - "--master_addresses={{ $root.Values.masterAddresses}}"
           - "--replication_factor={{ $root.Values.replicas.totalMasters }}"
@@ -306,10 +309,13 @@ spec:
           {{- else }}
           - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
           {{- end }}
-          - "--webserver_interface=0.0.0.0"
+          - "--webserver_interface={{ eq $root.Values.ip_version_support "v6_only" | ternary "[::]" "0.0.0.0" }}"
+          {{ if eq $root.Values.ip_version_support "v6_only" }}
+          - "--net_address_filter=ipv6_external,ipv6_non_link_local,ipv6_all,ipv4_external,ipv4_all"
+          {{ end }}
           {{ if not $root.Values.disableYsql }}
           - "--enable_ysql=true"
-          - "--pgsql_proxy_bind_address=0.0.0.0:5433"
+          - "--pgsql_proxy_bind_address={{ eq $root.Values.ip_version_support "v6_only" | ternary "[::]" "0.0.0.0" }}:5433"
           {{ else }}
           - "--enable_ysql=false"
           {{ end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -183,3 +183,5 @@ tolerations: []
 affinity: {}
 
 helm2Legacy: false
+
+ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -34,7 +34,7 @@ data:
     play.modules.enabled += "org.flywaydb.play.PlayModule"
 
     db {
-      default.url="jdbc:postgresql://127.0.0.1:5432/"${POSTGRES_DB}
+      default.url="jdbc:postgresql://{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:5432/"${POSTGRES_DB}
       default.driver=org.postgresql.Driver
       default.username=${POSTGRES_USER}
       default.password=${POSTGRES_PASSWORD}
@@ -50,7 +50,7 @@ data:
 
     yb {
       devops.home = /opt/yugabyte/devops
-      metrics.url = "http://127.0.0.1:9090/api/v1"
+      metrics.url = "http://{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9090/api/v1"
       storage.path = /opt/yugaware_data
       docker.network = bridge
       seedData = false
@@ -125,7 +125,7 @@ data:
       ssl_certificate_key /opt/certs/server.key;
       server_name  {{ .Values.tls.hostname }};
 {{- else }}
-      listen       80;
+      listen       {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:80" "80" }};
       server_name  {{ .Values.tls.hostname }};
 {{- end }}
       proxy_http_version 1.1;
@@ -134,7 +134,7 @@ data:
       proxy_set_header Host $host;
 
       location / {
-        proxy_pass http://127.0.0.1:9000;
+        proxy_pass http://{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9000;
       }
 
       location ~ "^/proxy/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}):([0-9]{4,6})/(.*)$" {
@@ -148,7 +148,7 @@ data:
       }
 
       location ~ "^/proxy/(.*.svc.cluster.local):([0-9]{4,6})/(.*)$" {
-        resolver 127.0.0.1:53 ipv6=off;
+        resolver {{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53" "127.0.0.1:53 ipv6=off"  }};
         proxy_pass "http://$1:$2/$3$is_args$args";
         sub_filter "http://" "/proxy/";
         sub_filter "href='/" "href='/proxy/$1:$2/";

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -227,7 +227,7 @@ spec:
           image: "janeczku/go-dnsmasq:release-1.0.7"
           args:
             - --listen
-            - "127.0.0.1:53"
+            - "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53"  "127.0.0.1:53" }}"
             - --default-resolver
             - --append-search-domains
             - --hostsfile=/etc/hosts

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -44,3 +44,5 @@ helm:
 domainName: "cluster.local"
 
 helm2Legacy: false
+
+ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment


### PR DESCRIPTION
Add a new flag to the helm chart for yugabyte and yugaware.

The flag is named `ip_version_support` which can be set to either `v4_only` or `v6_only` for now. When set to v6_only, the relevant address flags are modified to default to IPv6. The flag `--net_address_filter` is set to prefer IPv6 addresses when DNS names resolve to multiple IP addresses or when binding to wildcard addresses like `0.0.0.0` / `[::]` 

Test Plan:
Yugabyte: 

1. Generate yaml without this change  `helm template stable/yugabyte/  > /tmp/ht_default_no_over`
2. Generate yaml with this change and no overrides `helm template stable/yugabyte/  > /tmp/ht_default_all_ipv6_no_over`
3. Generate yaml with this change and the override `helm template stable/yugabyte/ --set ip_version_support=v6_only > /tmp/ht_all_ipv6_v6_only`

No changes between 1 and 2
```
foo$ diff /tmp/ht_default_no_over /tmp/ht_all_ipv6_no_over
269a270
>
465a467
>
```

Expected ipv6 flag changes between default and v6_only setting

```
 foo$ diff /tmp/ht_default_no_over /tmp/ht_all_ipv6_v6_only
268c268,271
<           - "--webserver_interface=0.0.0.0"
---
>           - "--webserver_interface=[::]"
>
>           - "--net_address_filter=ipv6_external,ipv6_non_link_local,ipv6_all,ipv4_external,ipv4_all"
>
464c467,470
<           - "--webserver_interface=0.0.0.0"
---
>           - "--webserver_interface=[::]"
>
>           - "--net_address_filter=ipv6_external,ipv6_non_link_local,ipv6_all,ipv4_external,ipv4_all"
>
467c473
<           - "--pgsql_proxy_bind_address=0.0.0.0:5433"
---
>           - "--pgsql_proxy_bind_address=[::]:5433"
```

Similar diff for yugaware helm chart

```
 helm_ipv6$ diff /tmp/yw_default_no_over /tmp/yw_all_ipv6_no_over
35c35
37c37
```

Diff with IPV6 off vs on

```
helm_ipv6$ diff /tmp/yw_all_ipv6_no_over /tmp/yw_all_ipv6_v6_only
35c35
58c58
<       default.url="jdbc:postgresql://127.0.0.1:5432/"${POSTGRES_DB}
---
>       default.url="jdbc:postgresql://[::1]:5432/"${POSTGRES_DB}
74c74
<       metrics.url = "http://127.0.0.1:9090/api/v1"
---
>       metrics.url = "http://[::1]:9090/api/v1"
126c126
<       listen       80;
---
>       listen       [::]:80;
134c134
<         proxy_pass http://127.0.0.1:9000;
---
>         proxy_pass http://[::1]:9000;
148c148
<         resolver 127.0.0.1:53 ipv6=off;
---
>         resolver [::1]:53;
581c581
<             - "127.0.0.1:53"
---
>             - "[::1]:53"
```
