### PR TITLE
Elevate hardcoded image repos/tags to values

### DIFF
--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -100,7 +100,7 @@ spec:
             secretName: {{ .Release.Name }}-yugaware-tls-cert
         {{- end }}
       containers:
-        - image: postgres:11.5
+        - image: {{ .Values.postgres.repository }}:{{ .Values.postgres.tag }}
           name: postgres
           env:
             - name: POSTGRES_USER
@@ -128,7 +128,7 @@ spec:
               mountPath: /var/lib/postgresql/data
               subPath: postgres_data
         - name: prometheus
-          image: prom/prometheus:v2.2.1
+          image: {{ .Values.prometheus.repository }}:{{ .Values.prometheus.tag }}
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -145,7 +145,7 @@ spec:
           ports:
             - containerPort: 9090
         - name: thirdparty-deps
-          image: quay.io/yugabyte/thirdparty-deps:latest
+          image: {{ .Values.yugaware.thirdparty-deps.repository }}:{{ .Values.yugaware.thirdparty-deps.tag }}
           command: [ "/bin/sh", "-c", "--" ]
           args:  [ "while true; do sleep 30; done;" ]
           volumeMounts:
@@ -212,7 +212,7 @@ spec:
             mountPath: /opt/swamper_targets/
             subPath: swamper_targets
         - name: nginx
-          image: nginx:1.17.4
+          image: {{ .Values.nginx.repository }}:{{ .Values.nginx.tag }}
           ports:
           - containerPort: 80
           volumeMounts:
@@ -224,7 +224,7 @@ spec:
             readOnly: true
           {{- end }}
         - name: dnsmasq
-          image: "janeczku/go-dnsmasq:release-1.0.7"
+          image: {{ .Values.dnsmasq.repository }}:{{ .Values.dnsmasq.tag }}
           args:
             - --listen
             - "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53"  "127.0.0.1:53" }}"

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -145,7 +145,7 @@ spec:
           ports:
             - containerPort: 9090
         - name: thirdparty-deps
-          image: {{ .Values.yugaware.thirdparty-deps.repository }}:{{ .Values.yugaware.thirdparty-deps.tag }}
+          image: {{ .Values.yugaware.thirdpartydeps.repository }}:{{ .Values.yugaware.thirdpartydeps.tag }}
           command: [ "/bin/sh", "-c", "--" ]
           args:  [ "while true; do sleep 30; done;" ]
           volumeMounts:

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -25,7 +25,7 @@ dnsmasq:
   tag: release-1.0.7
   
 yugaware:
-  thirdparty-deps:
+  thirdpartydeps:
     repository: quay.io/yugabyte/thirdparty-deps
     tag: latest
   replicas: 1

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -8,7 +8,26 @@ image:
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
 
+postgres:
+  repository: postgres
+  tag: 11.5
+
+prometheus:
+  repository: prom/prometheus
+  tag: v2.2.1
+
+nginx:
+  repository: nginx
+  tag: 1.17.4
+
+dnsmasq:
+  repository: janeczku/go-dnsmasq
+  tag: release-1.0.7
+  
 yugaware:
+  thirdparty-deps:
+    repository: quay.io/yugabyte/thirdparty-deps
+    tag: latest
   replicas: 1
   storage: 100Gi
   storageClass: standard


### PR DESCRIPTION
I have moved image repository names and versions to values.yaml to be overridden by users that might want to use internal mirrors.

`thirdparty-deps` might be tricky if the repo is set to private