### PR TITLE
Branch awareness

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -3,6 +3,8 @@ on:
   repository_dispatch:
     types:
     - update-on-release
+env:
+  CURRENT_STABLE: 2.3
 jobs:
   update-version:
     if: github.event.client_payload.prerelease == 'false'
@@ -30,6 +32,22 @@ jobs:
         fi
         echo "Extracted the version number '${version_number}'."
         echo "::set-output name=yb_version::${version_number}"
+    - name: "Switch to correct branch"
+      run: |
+        rel=${{steps.extract-version.outputs.yb_version}}
+        a=( ${rel//./ } )
+        branch_name="${a[0]}.${a[1]}"
+        if [[ "${branch_name}" == "${CURRENT_STABLE}" ]]; then # 2.3 is the latest "master" release
+          branch_name='master'
+        fi
+        if git branch | grep -qE "^${branch_name}$"; then
+          # branch laready exists so check it out
+          git checkout ${branch_name}
+        else
+          # First time creating charts for this release
+          # This won't start working 'correctly' till 2.4
+          git checkout -b ${branch_name} origin/master
+        fi
     - name: "Check python version and install dependencies"
       run: |
         python3 --version

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      fetch-depth: 1
     - name: "Configure git"
       run: |
         git config user.name 'YugaByte CI'
@@ -33,6 +34,7 @@ jobs:
         echo "Extracted the version number '${version_number}'."
         echo "::set-output name=yb_version::${version_number}"
     - name: "Switch to correct branch"
+      id: extract-branch
       run: |
         rel=${{steps.extract-version.outputs.yb_version}}
         a=( ${rel//./ } )
@@ -41,13 +43,17 @@ jobs:
           branch_name='master'
         fi
         if git branch | grep -qE "^${branch_name}$"; then
-          # branch laready exists so check it out
+          # branch already exists so check it out
           git checkout ${branch_name}
         else
           # First time creating charts for this release
           # This won't start working 'correctly' till 2.4
+          # till then, we will need to manually create the new branches and seed them with
+          # sufficiently old version numbers (the update script won't go down versions)
           git checkout -b ${branch_name} origin/master
         fi
+        echo "Extracted the branch: '${branch_name}'"
+        echo "::set-output name=yb_branch::${branch_name}"
     - name: "Check python version and install dependencies"
       run: |
         python3 --version
@@ -65,7 +71,7 @@ jobs:
         git add ./stable/yugabyte/Chart.yaml ./stable/yugaware/Chart.yaml \
                 ./stable/yugabyte/values.yaml ./stable/yugaware/values.yaml ./stable/yugabyte/app-readme.md
         git commit -m "Update the version to ${{steps.extract-version.outputs.yb_version}}"
-        git push origin ${{ github.ref }}
+        git push
     - name: "Show git status in case of failure"
       if: steps.update-version.outcome == 'failure'
       run: |

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -3,8 +3,6 @@ on:
   repository_dispatch:
     types:
     - update-on-release
-env:
-  CURRENT_STABLE: 2.3
 jobs:
   update-version:
     if: github.event.client_payload.prerelease == 'false'
@@ -34,14 +32,11 @@ jobs:
         echo "Extracted the version number '${version_number}'."
         echo "::set-output name=yb_version::${version_number}"
     - name: "Switch to correct branch"
-      id: extract-branch
+      id: switch-branch
       run: |
-        rel=${{steps.extract-version.outputs.yb_version}}
-        a=( ${rel//./ } )
-        branch_name="${a[0]}.${a[1]}"
-        if [[ "${branch_name}" == "${CURRENT_STABLE}" ]]; then # 2.3 is the latest "master" release
-          branch_name='master'
-        fi
+        # We use the yb_release_train as the branch in this repo
+        # This allows us to map multiple '2.2' release branches to a single set of helm charts
+        branch_name="${{github.events.client_payload.yb_release_train}}"
         if git branch | grep -qE "^${branch_name}$"; then
           # branch already exists so check it out
           git checkout ${branch_name}


### PR DESCRIPTION
This creates separate branches for each release series (2.1, 2.2, etc).
Not sure how this will play with the helm repo site.  I'll have an alternative approaching using release directories in master branch shortly.