### PR TITLE
Create a symlink to cores directory based on core_pattern

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -237,10 +237,19 @@ spec:
           postStart:
             exec:
               command:
-                - "sh"
+                - "bash"
                 - "-c"
                 - >
                   mkdir -p /mnt/disk0/cores;
+                  pattern="$(sysctl kernel.core_pattern --values || true)";
+                  core_dir="${pattern%/*}";
+                  if [ "${core_dir:0:1}" = "/" ]; then
+                    if [ ! -d "${core_dir}" ]; then
+                      # create the parent directory
+                      mkdir -p "${core_dir%/*}" || true;
+                      ln -s "/mnt/disk0/cores" "${core_dir}" || true;
+                    fi;
+                  fi;
                   mkdir -p /mnt/disk0/yb-data/scripts;
                   if [ ! -f /mnt/disk0/yb-data/scripts/log_cleanup.sh ]; then
                     if [ -f /home/yugabyte/bin/log_cleanup.sh ]; then


### PR DESCRIPTION
Modifies the postStart hook to create a symlink to /mnt/disk0/cores at
the directory being used by kernel.core_pattern. This is useful when
the core_pattern's value points to some absolute path like
/var/lib/cores instead of a relative path and the path doesn't exist
inside the container.

Changing to bash as some of the bash constructs are being used. The
current container image's sh is just a symlink to bash.

Ref: https://github.com/yugabyte/yugabyte-db/issues/4385#issuecomment-717656848

### Scenarios tested
- Installed the chart on nodes having `kernel.core_pattern=/var/lib/test/cores123/core.%e.%p.%t`.
- Exec into the pod,
  ```console
  $ ls -ll /var/lib/test
  total 0
  lrwxrwxrwx 1 root root 16 Nov  2 13:45 cores123 -> /mnt/disk0/cores

  $ /home/yugabyte/dumpit 
  Hello World!
  Segmentation fault (core dumped)

  $ pwd
  /mnt/disk0/cores

  $ ls
  core.dumpit.78.1604324807
  ```