### PR TITLE
Mount datadir0/cores in yb-cleanup container

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -382,6 +382,9 @@ spec:
           - name: datadir0
             mountPath: /home/yugabyte/
             subPath: yb-data
+          - name: datadir0
+            mountPath: /var/yugabyte/cores
+            subPath: cores
       {{- end }}
 
       volumes:


### PR DESCRIPTION
This allows the log_cleanup.sh to clean old core dump files. 

Ref: https://github.com/yugabyte/yugabyte-db/pull/6272