### PR TITLE
To configure username and password using Helm

### DIFF
--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -1,0 +1,66 @@
+{{- if or .Values.authCredentials.ycql.user .Values.authCredentials.ycql.password .Values.authCredentials.ycql.keyspace .Values.authCredentials.ysql.password .Values.authCredentials.ysql.user .Values.authCredentials.ysql.database }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "yugabyte.fullname" . }}-setup-credentials
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: "setup-credentials"
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    component: "{{ .Values.Component }}"
+  annotations:
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      name: "setup-credentials"
+      labels:
+        app: "setup-credentials"
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}"
+        component: "{{ .Values.Component }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: setup-credentials
+        image: "{{ .Values.Image.repository }}:{{ .Values.Image.tag }}"
+        env:
+        {{- if .Values.authCredentials.ysql.user }}
+        - name: YSQL_USER
+          value: "{{ .Values.authCredentials.ysql.user }}"
+        {{- end }}
+        {{- if .Values.authCredentials.ysql.password }}
+        - name: YSQL_PASSWORD
+          value: "{{ .Values.authCredentials.ysql.password }}"
+        {{- end }}
+        {{- if .Values.authCredentials.ysql.database }}
+        - name: YSQL_DATABASE
+          value: "{{ .Values.authCredentials.ysql.database }}"
+        {{- end }}
+        {{- if .Values.authCredentials.ycql.user }}
+        - name: YCQL_USER
+          value: "{{ .Values.authCredentials.ycql.user }}"
+        {{- end }}
+        {{- if .Values.authCredentials.ycql.password }}
+        - name: YCQL_PASSWORD
+          value: "{{ .Values.authCredentials.ycql.password }}"
+        {{- end }}
+        {{- if .Values.authCredentials.ycql.keyspace }}
+        - name: YCQL_KEYSPACE
+          value: "{{ .Values.authCredentials.ycql.keyspace }}"
+        {{- end }}
+        command:
+        - 'bash'
+        - '/home/yugabyte/bin/setup-credentials/setup-credentials.sh'
+        volumeMounts:
+        - name: setup-credentials-script
+          mountPath: "/home/yugabyte/bin/setup-credentials"
+      volumes:
+      - name: setup-credentials-script
+        configMap:
+          name: {{ include "yugabyte.fullname" . }}-setup-credentials-script
+{{- end }}

--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -38,7 +38,7 @@ spec:
           value: "{{ .Values.authCredentials.ysql.password }}"
         {{- end }}
         {{- if .Values.authCredentials.ysql.database }}
-        - name: YSQL_DATABASE
+        - name: YSQL_DB
           value: "{{ .Values.authCredentials.ysql.database }}"
         {{- end }}
         {{- if .Values.authCredentials.ycql.user }}
@@ -53,14 +53,28 @@ spec:
         - name: YCQL_KEYSPACE
           value: "{{ .Values.authCredentials.ycql.keyspace }}"
         {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: SSL_CERTFILE
+          value: "/root/.yugabytedb/root.crt"
+        {{- end }}
         command:
         - 'bash'
         - '/home/yugabyte/bin/setup-credentials/setup-credentials.sh'
         volumeMounts:
         - name: setup-credentials-script
           mountPath: "/home/yugabyte/bin/setup-credentials"
+        {{- if .Values.tls.enabled }}
+        - name: yugabyte-tls-client-cert
+          mountPath: "/root/.yugabytedb/"
+        {{- end }}
       volumes:
       - name: setup-credentials-script
         configMap:
           name: {{ include "yugabyte.fullname" . }}-setup-credentials-script
+      {{- if .Values.tls.enabled }}
+      - name: yugabyte-tls-client-cert
+        secret:
+          secretName: yugabyte-tls-client-cert
+          defaultMode: 256
+      {{- end }}
 {{- end }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -329,6 +329,12 @@ spec:
           - "--stderrthreshold=0"
           - "--num_cpus={{ ceil $root.Values.resource.tserver.requests.cpu }}"
           - "--undefok=num_cpus,enable_ysql"
+          {{- if $root.Values.authCredentials.ysql.password }}
+          - "--ysql_enable_auth=true"
+          {{- end }}
+          {{- if or $root.Values.authCredentials.ycql.user $root.Values.authCredentials.ycql.password }}
+          - "--use_cassandra_authentication=true"
+          {{- end }}
           {{- range $flag, $override := $root.Values.gflags.tserver }}
           - "--{{ $flag }}={{ $override }}"
           {{- end }}

--- a/stable/yugabyte/templates/setup-credentials-configmap.yaml
+++ b/stable/yugabyte/templates/setup-credentials-configmap.yaml
@@ -1,0 +1,249 @@
+{{- if or .Values.authCredentials.ycql.user .Values.authCredentials.ycql.password .Values.authCredentials.ycql.keyspace .Values.authCredentials.ysql.password .Values.authCredentials.ysql.user .Values.authCredentials.ysql.database }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "yugabyte.fullname" . }}-setup-credentials-script
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}"
+    component: "{{ .Values.Component }}"
+data:
+  setup-credentials.sh: |
+    #!/bin/bash
+
+    set -eo pipefail
+
+    # Setup script to setup credentials
+
+    # -----------------------------------------
+    # Default Variables
+    # -----------------------------------------
+
+    readonly DEFAULT_YSQL_USER="yugabyte"
+    readonly DEFAULT_YSQL_PASSWORD="yugabyte"
+    readonly DEFAULT_YSQL_DB="yugabyte"
+
+    readonly DEFAULT_YCQL_USER="cassandra"
+    readonly DEFAULT_YCQL_PASSWORD="cassandra"
+
+    {{- range .Values.Services }}
+    {{- $service := . -}}
+      {{- if eq ($service.name) "yb-tservers" }}
+        readonly YSQL_PORT={{ index $service.ports "tcp-ysql-port" }}
+        # TODO: Update the tcp-yql-port to tcp-ycql-port in values.yaml
+        readonly YCQL_PORT={{ index $service.ports "tcp-yql-port" }}
+      {{- end }}
+    {{- end }}
+
+    readonly prefix_ysql_cmd=(
+      /home/yugabyte/bin/ysqlsh -h yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+      -p "$YSQL_PORT"
+    )
+
+    readonly prefix_ycql_cmd=(
+      /home/yugabyte/bin/ycqlsh yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+      "$YCQL_PORT"
+    )
+
+    # -----------------------------------------
+    # Variables
+    # -----------------------------------------
+
+    ysql_user=
+    ysql_password=
+    ysql_db=
+    ycql_user=
+    ycql_password=
+    ycql_keyspace=
+
+    # -----------------------------------------
+    # Hepler functions
+    # -----------------------------------------
+
+    cleanup() {
+      local exit_code=$?
+      echo "Exiting with code $exit_code"
+      exit "$exit_code"
+    }
+
+    function waitUntilHealthy() {
+      declare -a ysql_cmd
+      export PGPASSWORD="$2"
+      ysql_cmd=(
+        /home/yugabyte/bin/ysqlsh -h yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+        -p "$3"
+        -U "$1"
+        -c "\\conninfo"
+      )
+      echo "${ysql_cmd[@]}"
+      while ! "${ysql_cmd[@]}"; do
+        sleep 5s
+      done
+    }
+
+    export -f waitUntilHealthy
+
+    get_ysql_credentials() {
+      [[ -n "$YSQL_USER" ]] && ysql_user="$YSQL_USER" || ysql_user="$DEFAULT_YSQL_USER"
+
+      [[ -n "$YSQL_PASSWORD" ]] && ysql_password="$YSQL_PASSWORD"
+
+      if [[ -z "$YSQL_PASSWORD" ]] && [[ "$ysql_user" != "$DEFAULT_YSQL_USER" ]]; then
+        ysql_password="$YSQL_USER"
+      fi
+
+      [[ -n "$YSQL_DB" ]] && ysql_db="$YSQL_DB"
+
+      [[ -z "$YSQL_DB" ]] && [[ -n "$YSQL_USER" ]] && ysql_db="$ysql_user"
+
+      api="ysql"
+    }
+
+    get_ycql_credentials() {
+      [[ -n "$YCQL_USER" ]] && ycql_user="$YCQL_USER" || ycql_user="$DEFAULT_YCQL_USER"
+
+      [[ -n "$YCQL_PASSWORD" ]] && ycql_password="$YCQL_PASSWORD"
+
+      if [[ -z "$YCQL_PASSWORD" ]] && [[ "$ycql_user" != "$DEFAULT_YCQL_USER" ]]; then
+        ycql_password="$YCQL_USER"
+      fi
+
+      [[ -n "$YCQL_KEYSPACE" ]] && ycql_keyspace="$YCQL_KEYSPACE"
+
+      [[ -z "$YCQL_KEYSPACE" ]] && [[ -n "$YCQL_USER" ]] && ycql_keyspace="$ycql_user"
+
+      api="ycql"
+    }
+
+    create_user() {
+      declare -a ysql_cmd
+      declare -a ycql_cmd
+
+      case "$api" in
+      "ysql")
+        export PGPASSWORD="$DEFAULT_YSQL_PASSWORD"
+        read -r -a ysql_cmd <<< "${prefix_ysql_cmd[@]}"
+        ysql_cmd+=(
+          -U "$DEFAULT_YSQL_USER"
+          -c "CREATE ROLE IF NOT EXISTS ${ysql_user} with LOGIN SUPERUSER password '${ysql_password}' ;"
+          -c "ALTER DATABASE ${ysql_db} OWNER TO ${ysql_user} ;"
+        )
+        "${ysql_cmd[@]}"
+      ;;
+      "ycql")
+        read -r -a ycql_cmd <<< "${prefix_ycql_cmd[@]}"
+        ycql_cmd+=(
+          -u "$DEFAULT_YCQL_USER"
+          -p "$DEFAULT_YCQL_PASSWORD"
+          -e "CREATE ROLE IF NOT EXISTS ${ycql_user} WITH PASSWORD = '${ycql_password}' AND LOGIN = true AND SUPERUSER = true ;"
+        )
+        "${ycql_cmd[@]}"
+      ;;
+      *) exit 1
+      esac
+    }
+
+    update_password() {
+      declare -a ysql_cmd
+      declare -a ycql_cmd
+
+      case "$api" in
+      "ysql")
+        export PGPASSWORD="$DEFAULT_YSQL_PASSWORD"
+        read -r -a ysql_cmd <<< "${prefix_ysql_cmd[@]}"
+        ysql_cmd+=(
+          -U "$DEFAULT_YSQL_USER"
+          -c "ALTER ROLE ${ysql_user} WITH PASSWORD '${ysql_password}' ;"
+        )
+        "${ysql_cmd[@]}"
+      ;;
+      "ycql")
+        read -r -a ycql_cmd <<< "${prefix_ycql_cmd[@]}"
+        ycql_cmd+=(
+          -u "$DEFAULT_YCQL_USER"
+          -p "$DEFAULT_YCQL_PASSWORD"
+          -e "ALTER ROLE ${ycql_user} WITH PASSWORD = '${ycql_password}' ;"
+        )
+        "${ycql_cmd[@]}"
+      ;;
+      *) exit 1
+      esac
+    }
+
+    create_container() {
+      declare -a ysql_cmd
+      declare -a ycql_cmd
+
+      case "$api" in
+        "ysql")
+          export PGPASSWORD="$DEFAULT_YSQL_PASSWORD"
+          read -r -a ysql_cmd <<< "${prefix_ysql_cmd[@]}"
+          ysql_cmd+=(
+            -U "$DEFAULT_YSQL_USER"
+            -c "CREATE DATABASE IF NOT EXISTS ${ysql_db} ;"
+          )
+          "${ysql_cmd[@]}"
+        ;;
+        "ycql")
+          read -r -a ycql_cmd <<< "${prefix_ycql_cmd[@]}"
+          ycql_cmd+=(
+            -u "$DEFAULT_YCQL_USER"
+            -p "$DEFAULT_YCQL_PASSWORD"
+            -e "CREATE KEYSPACE IF NOT EXISTS ${ycql_keyspace} ;"
+          )
+          "${ycql_cmd[@]}"
+        ;;
+        *) exit 1
+      esac
+    }
+
+    # -----------------------------------------
+    # Main
+    # -----------------------------------------
+
+    trap cleanup EXIT
+
+    echo "Waiting for YugabyteDB to start."
+    if ! timeout 3m bash -c "waitUntilHealthy ${DEFAULT_YSQL_USER} ${DEFAULT_YSQL_PASSWORD} ${YSQL_PORT}"; then
+      echo "Timeout while waiting for database"
+      exit 1
+    fi
+
+    # YSQL Credentials
+    get_ysql_credentials
+
+    ## Create YSQL DB
+    if [[ -n $ysql_db ]] && [[ "$ysql_db" != "$DEFAULT_YSQL_DB" ]]; then
+      create_container
+    fi
+
+    ## Update YSQL Password
+    if [[ -n $ysql_password ]] && [[ "$ysql_password" != "$DEFAULT_YSQL_PASSWORD" ]] && [[ "$ysql_user" == "$DEFAULT_YSQL_USER" ]]; then
+      update_password
+    fi
+
+    ## Create YSQL User
+    if [[ -n $ysql_user ]] && [[ "$ysql_user" != "$DEFAULT_YSQL_USER" ]]; then
+      create_user
+    fi
+
+    # YCQL Credentials
+    get_ycql_credentials
+
+    ## Create YCQL Keyspace
+    if [[ -n $ycql_keyspace ]] && [[ -n "$ycql_keyspace" ]]; then
+      create_container
+    fi
+
+    ## Update YCQL Password
+    if [[ -n $ycql_password ]] && [[ "$ycql_password" != "$DEFAULT_YCQL_PASSWORD" ]] && [[ "$ycql_user" == "$DEFAULT_YCQL_USER" ]]; then
+      update_password
+    fi
+
+    ## Create YCQL User
+    if [[ -n $ycql_user ]] && [[ "$ycql_user" != "$DEFAULT_YCQL_USER" ]]; then
+      create_user
+    fi
+
+{{- end }}

--- a/stable/yugabyte/templates/setup-credentials-configmap.yaml
+++ b/stable/yugabyte/templates/setup-credentials-configmap.yaml
@@ -36,15 +36,20 @@ data:
       {{- end }}
     {{- end }}
 
-    readonly prefix_ysql_cmd=(
+    prefix_ysql_cmd=(
       /home/yugabyte/bin/ysqlsh -h yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
       -p "$YSQL_PORT"
     )
 
-    readonly prefix_ycql_cmd=(
+    prefix_ycql_cmd=(
       /home/yugabyte/bin/ycqlsh yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
       "$YCQL_PORT"
     )
+
+    {{- if .Values.tls.enabled }}
+      prefix_ysql_cmd+=("sslmode=require")
+      prefix_ycql_cmd+=(--ssl)
+    {{- end }}
 
     # -----------------------------------------
     # Variables
@@ -76,6 +81,11 @@ data:
         -U "$1"
         -c "\\conninfo"
       )
+
+      if [[ "$4" == "true" ]]; then
+        ysql_cmd+=("sslmode=require")
+      fi
+
       echo "${ysql_cmd[@]}"
       while ! "${ysql_cmd[@]}"; do
         sleep 5s
@@ -126,7 +136,7 @@ data:
         read -r -a ysql_cmd <<< "${prefix_ysql_cmd[@]}"
         ysql_cmd+=(
           -U "$DEFAULT_YSQL_USER"
-          -c "CREATE ROLE IF NOT EXISTS ${ysql_user} with LOGIN SUPERUSER password '${ysql_password}' ;"
+          -c "CREATE ROLE ${ysql_user} with LOGIN SUPERUSER password '${ysql_password}' ;"
           -c "ALTER DATABASE ${ysql_db} OWNER TO ${ysql_user} ;"
         )
         "${ysql_cmd[@]}"
@@ -181,7 +191,7 @@ data:
           read -r -a ysql_cmd <<< "${prefix_ysql_cmd[@]}"
           ysql_cmd+=(
             -U "$DEFAULT_YSQL_USER"
-            -c "CREATE DATABASE IF NOT EXISTS ${ysql_db} ;"
+            -c "CREATE DATABASE ${ysql_db} ;"
           )
           "${ysql_cmd[@]}"
         ;;
@@ -205,7 +215,7 @@ data:
     trap cleanup EXIT
 
     echo "Waiting for YugabyteDB to start."
-    if ! timeout 3m bash -c "waitUntilHealthy ${DEFAULT_YSQL_USER} ${DEFAULT_YSQL_PASSWORD} ${YSQL_PORT}"; then
+    if ! timeout 3m bash -c "waitUntilHealthy ${DEFAULT_YSQL_USER} ${DEFAULT_YSQL_PASSWORD} ${YSQL_PORT} {{ .Values.tls.enabled }}"; then
       echo "Timeout while waiting for database"
       exit 1
     fi

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -54,8 +54,6 @@ tls:
 gflags:
   master:
     default_memory_limit_to_ram_ratio: 0.85
-  tserver:
-    use_cassandra_authentication: false
 
 PodManagementPolicy: Parallel
 
@@ -185,3 +183,14 @@ affinity: {}
 helm2Legacy: false
 
 ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment
+
+# For more https://docs.yugabyte.com/latest/reference/configuration/yugabyted/#environment-variables
+authCredentials:
+  ysql:
+    user: ""
+    password: ""
+    database: ""
+  ycql:
+    user: ""
+    password: ""
+    keyspace: ""

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -54,6 +54,8 @@ tls:
 gflags:
   master:
     default_memory_limit_to_ram_ratio: 0.85
+# tserver:
+#   use_cassandra_authentication: false
 
 PodManagementPolicy: Parallel
 


### PR DESCRIPTION
## Summary

Added implementation to configure the username and password for YSQL and YCQL using Helm.

**Flow:**
Added post-install hook job to set up the credentials. The post-install hook job gets the script from ConfigMap. The hook job sets the custom credentials in the environment vars & the `setup credentials` script uses those environment vars for configuration.

[EDITED]
**Note:** 

- The changes work with TLS and Non-TLS clusters.

~~- The changes only work with the Non-TLS cluster.~~
~~- Compatible Changes for TLS is in-progress.~~

## Test Plan:
The changes have been tested with the mentioned env vars combination in `yugabyted` [reference docs](https://docs.yugabyte.com/latest/reference/configuration/yugabyted/#environment-variables). 

The following commands to test the changes (These changes are from the demo branch, and the branch is in development)-

1. The following commands are used to spin up the cluster with the custom `YSQL` password.
```sh
helm repo remove yugabytedb
helm repo add yugabytedb https://baba230896.github.io/charts
helm repo update
helm search repo yugabytedb/yugabyte
helm install yb-demo yugabytedb/yugabyte \
    --set resource.master.requests.cpu=150m,resource.master.requests.memory=100Mi,storage.master.size=3Gi \
    --set resource.tserver.requests.cpu=150m,resource.tserver.requests.memory=100Mi,storage.tserver.size=3Gi \
    --set replicas.tserver=3,replicas.master=3 \
    --set authCredentials.ysql.password=sqlpassword \
    --namespace ys-helm 
```
2. Verify the new password (Provide the new password in prompt).
```sh
kubectl exec -n ys-helm -it yb-tserver-0 -- ysqlsh -h yb-tserver-0.yb-tservers.ys-helm
```

## Fixes:
https://github.com/yugabyte/yugabyte-db/issues/5663