### PR TITLE
[YW] Making the registry of various images configurable

### DIFF
--- a/stable/yugaware/templates/_helpers.tpl
+++ b/stable/yugaware/templates/_helpers.tpl
@@ -30,3 +30,41 @@ Create chart name and version as used by the chart label.
 {{- define "yugaware.chart" -}}
 {{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Implements customization for the registry for component images.
+
+The preference is to use the image.commonRegistry field first if it is set.
+Otherwise the local registry override for each image is used if set, for ex: image.postgres.registry
+
+In both cases, the image name and tag can be customized by using the overrides for each image, for ex: image.postgres.name
+*/}}
+{{- define "full_image" -}}
+  {{- $specific_registry := (get (get .root.Values.image .containerName) "registry") -}}
+  {{- if not (empty .root.Values.image.commonRegistry) -}}
+    {{- $specific_registry = .root.Values.image.commonRegistry -}}
+  {{- end -}}
+ {{- if not (empty $specific_registry) -}}
+    {{- $specific_registry = printf "%s/" $specific_registry -}}
+  {{- end -}}
+  {{- $specific_name := (toString (get (get .root.Values.image .containerName) "name")) -}}
+  {{- $specific_tag := (toString (get (get .root.Values.image .containerName) "tag")) -}}
+  {{- printf "%s%s:%s" $specific_registry $specific_name $specific_tag  -}}
+{{- end -}}
+
+{{/*
+Implements customization for the registry for the yugaware docker image.
+
+The preference is to use the image.commonRegistry field first if it is set.
+Otherwise the image.repository field is used.
+
+In both cases, image.tag can be used to customize the tag of the yugaware image.
+*/}}
+{{- define "full_yugaware_image" -}}
+  {{- $specific_registry := .Values.image.repository -}}
+  {{- if not (empty .Values.image.commonRegistry) -}}
+    {{- $specific_registry = printf "%s/%s" .Values.image.commonRegistry "yugabyte/yugaware" -}}
+  {{- end -}}
+  {{- $specific_tag := (toString .Values.image.tag) -}}
+  {{- printf "%s:%s" $specific_registry $specific_tag  -}}
+{{- end -}}

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -100,7 +100,7 @@ spec:
             secretName: {{ .Release.Name }}-yugaware-tls-cert
         {{- end }}
       containers:
-        - image: postgres:11.5
+        - image: {{ include "full_image" (dict "containerName" "postgres" "root" .) }}
           name: postgres
           env:
             - name: POSTGRES_USER
@@ -128,7 +128,7 @@ spec:
               mountPath: /var/lib/postgresql/data
               subPath: postgres_data
         - name: prometheus
-          image: prom/prometheus:v2.2.1
+          image: {{ include "full_image" (dict "containerName" "prometheus" "root" .) }}
           securityContext:
             runAsUser: 0
           volumeMounts:
@@ -145,7 +145,7 @@ spec:
           ports:
             - containerPort: 9090
         - name: thirdparty-deps
-          image: quay.io/yugabyte/thirdparty-deps:latest
+          image: {{ include "full_image" (dict "containerName" "thirdparty-deps" "root" .) }}
           command: [ "/bin/sh", "-c", "--" ]
           args:  [ "while true; do sleep 30; done;" ]
           volumeMounts:
@@ -160,7 +160,7 @@ spec:
                   - '/opt/third-party'
                   - '/third-party-deps'
         - name: yugaware
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ include "full_yugaware_image" . }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -212,7 +212,7 @@ spec:
             mountPath: /opt/swamper_targets/
             subPath: swamper_targets
         - name: nginx
-          image: nginx:1.17.4
+          image: {{ include "full_image" (dict "containerName" "nginx" "root" .) }}
           ports:
           - containerPort: 80
           volumeMounts:
@@ -224,7 +224,7 @@ spec:
             readOnly: true
           {{- end }}
         - name: dnsmasq
-          image: "janeczku/go-dnsmasq:release-1.0.7"
+          image: {{ include "full_image" (dict "containerName" "dnsmasq" "root" .) }}
           args:
             - --listen
             - "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53"  "127.0.0.1:53" }}"

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -2,11 +2,41 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+
 image:
+  commonRegistry: ""
+  # Setting commonRegistry to say, quay.io overrides the registry settings for all images
+  # including the yugaware image
+
   repository: quay.io/yugabyte/yugaware
   tag: 2.3.2.0-b37
   pullPolicy: IfNotPresent
   pullSecret: yugabyte-k8s-pull-secret
+
+  thirdparty-deps:
+    registry: quay.io
+    tag: latest
+    name: yugabyte/thirdparty-deps
+
+  postgres:
+    registry: ""
+    tag: 11.5
+    name: postgres
+
+  prometheus:
+    registry: ""
+    tag: v2.2.1
+    name: prom/prometheus
+
+  nginx:
+    registry: ""
+    tag: 1.17.4
+    name: nginx
+
+  dnsmasq:
+    registry: ""
+    tag: release-1.0.7
+    name: janeczku/go-dnsmasq
 
 yugaware:
   replicas: 1


### PR DESCRIPTION
Summary: 
When YW is deployed in an environment with no internet access that uses a private image repo, we need to make all the different components of YW be pull-able from the private repo.

1. Each image can have a configurable registry and tag. I left the yugaware image configuration with the old process of configuring the repository tag directly.
2. A global override for all registries is also available and takes highest precedence for all images.

Test Plan:

Test with no overrides
```
sanketh@Sankeths-MacBook-Pro ~/code/charts repoconfig2$ helm template ~/code/charts/stable/yugaware > /tmp/tmp-charts/new.yaml; diff /tmp/tmp-charts/old.yaml /tmp/tmp-charts/new.yaml | egrep -v 'postgres_pass|app_sec'
35c35
---
37c37
---
578c578
<           image: "janeczku/go-dnsmasq:release-1.0.7"
---
>           image: janeczku/go-dnsmasq:release-1.0.7
```

Test with single registry override
```
anketh@Sankeths-MacBook-Pro ~/code/charts repoconfig2$ helm template ~/code/charts/stable/yugaware --set image.postgres.registry=quay1.io > /tmp/tmp-charts/new.yaml; diff /tmp/tmp-charts/old.yaml /tmp/tmp-charts/new.yaml | egrep -v 'postgres_pass|app_sec'
35c35
---
37c37
---
466c466
<         - image: postgres:11.5
---
>         - image: quay1.io/postgres:11.5
578c578
<           image: "janeczku/go-dnsmasq:release-1.0.7"
---
>           image: janeczku/go-dnsmasq:release-1.0.7
```

Test with commonRegistry override

```
sanketh@Sankeths-MacBook-Pro ~/code/charts repoconfig2$ helm template ~/code/charts/stable/yugaware --set image.commonRegistry=quay1.io > /tmp/tmp-charts/new.yaml; diff /tmp/tmp-charts/old.yaml /tmp/tmp-charts/new.yaml | egrep -v 'postgres_pass|app_sec'
35c35
---
37c37
---
466c466
<         - image: postgres:11.5
---
>         - image: quay1.io/postgres:11.5
494c494
<           image: prom/prometheus:v2.2.1
---
>           image: quay1.io/prom/prometheus:v2.2.1
511c511
<           image: quay.io/yugabyte/thirdparty-deps:latest
---
>           image: quay1.io/yugabyte/thirdparty-deps:latest
526c526
<           image: quay.io/yugabyte/yugaware:2.3.2.0-b37
---
>           image: quay1.io/yugabyte/yugaware:2.3.2.0-b37
571c571
<           image: nginx:1.17.4
---
>           image: quay1.io/nginx:1.17.4
578c578
<           image: "janeczku/go-dnsmasq:release-1.0.7"
---
>           image: quay1.io/janeczku/go-dnsmasq:release-1.0.7
```

Test with commmonRegistry override but also a specific tag and registry override. We expect commonRegistry to be reflected and the tag to be reflected.
```
sanketh@Sankeths-MacBook-Pro ~/code/charts repoconfig2$ helm template ~/code/charts/stable/yugaware --set image.commonRegistry=quay1.io,image.postgres.registry=quaypostgres.io,image.postgres.tag=9.0 > /tmp/tmp-charts/new.yaml; diff /tmp/tmp-charts/old.yaml /tmp/tmp-charts/new.yaml | egrep -v 'postgres_pass|app_sec'
35c35
---
37c37
---
466c466
<         - image: postgres:11.5
---
>         - image: quay1.io/postgres:9.0
494c494
<           image: prom/prometheus:v2.2.1
---
>           image: quay1.io/prom/prometheus:v2.2.1
511c511
<           image: quay.io/yugabyte/thirdparty-deps:latest
---
>           image: quay1.io/yugabyte/thirdparty-deps:latest
526c526
<           image: quay.io/yugabyte/yugaware:2.3.2.0-b37
---
>           image: quay1.io/yugabyte/yugaware:2.3.2.0-b37
571c571
<           image: nginx:1.17.4
---
>           image: quay1.io/nginx:1.17.4
578c578
<           image: "janeczku/go-dnsmasq:release-1.0.7"
---
>           image: quay1.io/janeczku/go-dnsmasq:release-1.0.7
```