### PR TITLE
Remove ip-based universe proxy from nginx config

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -139,16 +139,6 @@ data:
         proxy_pass http://{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9000;
       }
 
-      location ~ "^/proxy/([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}):([0-9]{4,6})/(.*)$" {
-        proxy_pass "http://$1:$2/$3$is_args$args";
-        sub_filter "http://" "/proxy/";
-        sub_filter "href='/" "href='/proxy/$1:$2/";
-        sub_filter "href=\"/" "href=\"/proxy/$1:$2/";
-        sub_filter "src='/" "src='/proxy/$1:$2/";
-        sub_filter "src=\"/" "src=\"/proxy/$1:$2/";
-        sub_filter_once off;
-      }
-
       location ~ "^/proxy/(.*.svc.cluster.local):([0-9]{4,6})/(.*)$" {
         resolver {{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53" "127.0.0.1:53 ipv6=off"  }};
         proxy_pass "http://$1:$2/$3$is_args$args";


### PR DESCRIPTION
I only removed the ipv4-based proxy for ip-based universes for now, because a tiny bit more work will need to go into the YW proxy API to support ipv6 k8s clusters. The UI will default to trying to hit the new proxy API now regardless of deployment type, but at least we still have a "backdoor" way to hit the old proxy endpoint for k8s clusters if need-be (specifically thinking about the ipv6 case for now)