### PR TITLE
[yugaware] Changes for compatibility with OpenShift

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -32,6 +32,8 @@ data:
     pidfile.path = "/dev/null"
     play.evolutions.enabled=false
     play.modules.enabled += "org.flywaydb.play.PlayModule"
+    play.logger.includeConfigProperties=true
+    log.override.path = "/opt/yugaware_data/logs"
 
     db {
       default.url="jdbc:postgresql://{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:5432/"${POSTGRES_DB}
@@ -122,12 +124,12 @@ data:
   default.conf: |
     server {
 {{- if .Values.tls.enabled }}
-      listen       443 ssl;
+      listen       8443 ssl;
       ssl_certificate /opt/certs/server.crt;
       ssl_certificate_key /opt/certs/server.key;
       server_name  {{ .Values.tls.hostname }};
 {{- else }}
-      listen       {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:80" "80" }};
+      listen       {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:8080" "8080" }};
       server_name  {{ .Values.tls.hostname }};
 {{- end }}
       proxy_http_version 1.1;
@@ -150,7 +152,7 @@ data:
       }
 
       location ~ "^/proxy/(.*.svc.cluster.local):([0-9]{4,6})/(.*)$" {
-        resolver {{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53" "127.0.0.1:53 ipv6=off"  }};
+        resolver {{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53" "127.0.0.1:5353 ipv6=off"  }};
         proxy_pass "http://$1:$2/$3$is_args$args";
         sub_filter "http://" "/proxy/";
         sub_filter "href='/" "href='/proxy/$1:$2/";

--- a/stable/yugaware/templates/rbac.yaml
+++ b/stable/yugaware/templates/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
     k8s-app: yugaware
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+{{- if .Values.rbac.create }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -61,3 +62,4 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -27,8 +27,10 @@ spec:
   - name: ui
 {{- if .Values.tls.enabled }}
     port: 443
+    targetPort: 8443
 {{- else }}
     port: 80
+    targetPort: 8080
 {{- end }}
   - name: metrics
     port: 9090
@@ -129,8 +131,10 @@ spec:
               subPath: postgres_data
         - name: prometheus
           image: {{ include "full_image" (dict "containerName" "prometheus" "root" .) }}
+          {{- if (not .Values.ocpCompatibility.enabled) }}
           securityContext:
             runAsUser: 0
+          {{- end }}
           volumeMounts:
           - name: prometheus-config
             mountPath: /etc/prometheus/
@@ -214,7 +218,7 @@ spec:
         - name: nginx
           image: {{ include "full_image" (dict "containerName" "nginx" "root" .) }}
           ports:
-          - containerPort: 80
+          - containerPort: 8080
           volumeMounts:
           - mountPath: /etc/nginx/conf.d/
             name: nginx-config
@@ -227,8 +231,7 @@ spec:
           image: {{ include "full_image" (dict "containerName" "dnsmasq" "root" .) }}
           args:
             - --listen
-            - "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53"  "127.0.0.1:53" }}"
-            - --default-resolver
+            - "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:5353"  "127.0.0.1:5353" }}"
             - --append-search-domains
             - --hostsfile=/etc/hosts
             - --verbose

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -30,8 +30,8 @@ image:
 
   nginx:
     registry: ""
-    tag: 1.17.4
-    name: nginx
+    tag: 1.17.4-amd64
+    name: nginxinc/nginx-unprivileged
 
   dnsmasq:
     registry: ""
@@ -76,3 +76,14 @@ domainName: "cluster.local"
 helm2Legacy: false
 
 ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment
+
+rbac:
+  ## Does not create (Cluster) Role and Binding if false. When set to
+  ## false, some of the graphs from Container section of the Metrics
+  ## UI don't work.
+  create: true
+
+## In order to deploy on OpenShift Container Platform, set this to
+## true.
+ocpCompatibility:
+  enabled: false


### PR DESCRIPTION
-   Use nginxinc/nginx-unprivileged image and use port 8443 and 8080 of the container. The ports exposed by the service remain the same.
-   Add a new option `rbac.enabled` which makes it possible to turn off the ClusterRole and ClusterRoleBinding creation.
-   Add a new option `ocpCompatibility.enabled` which removes runAsUser: 0 securityContext from prometheus container. Not changing the default securityContext here to make sure that old deployments continue to function with this change.
-   dnsmasq binds to 5353 instead of 53 now, remove the `--default-resolver` flag as well, otherwise dnsmasq modifies the `/etc/resolv.conf` and adds itself as nameserver as 127.0.0.1 without mentioning the port. This results in broken DNS setup inside the container.
    
    The /etc/resolv.conf looks like this when --default-resolver is specified
    
    ```conf
    nameserver 127.0.0.1 # added by go-dnsmasq
    # disabled by go-dnsmasq # nameserver 10.0.0.10
    search yw-test.svc.cluster.local svc.cluster.local cluster.local …
    options ndots:5
    ```

### Scenarios tested

-   Installed latest chart and created one universe in a GKE cluster.
    
    ```
    helm3 install yw yugabytedb/yugaware -n yw-test --set image.tag=2.5.0.0-b2 --set tls.enabled=true
    ```
-   Upgraded it with same image and new changes. Proxy, the Kubernetes service and other basic functionality is working.
    
    ```
    helm3 upgrade yw -n yw-test ~/src/yugabyte-charts/stable/yugaware/ 
    ```
-   Tested same steps with 2.5.0.0-b2 to latest build YW image (from source) and with TLS.

- Tested the same setup on OCP with 
   ```
   helm3 install yw-test ~/src/yugabyte-charts/stable/yugaware/ --set ocpCompatibility.enabled=true --set rbac.create=false
   ```

Fixes https://github.com/yugabyte/yugabyte-db/issues/6548 Fixes https://github.com/yugabyte/yugabyte-db/issues/6431 Fixes https://github.com/yugabyte/yugabyte-db/issues/6617