### PR TITLE
[openshift] Improved yb-cleanup to run on OpenShift

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -377,12 +377,9 @@ spec:
           - "/bin/sh"
           - "-c"
           - >
-            mkdir /var/spool/cron;
-            mkdir /var/spool/cron/crontabs;
-            echo "0 * * * * /home/yugabyte/scripts/log_cleanup.sh" | tee -a /var/spool/cron/crontabs/root;
-            crond;
             while true; do
-              sleep 86400;
+              sleep 3600;
+              /home/yugabyte/scripts/log_cleanup.sh;
             done
         volumeMounts:
           - name: datadir0


### PR DESCRIPTION
### Summary

Modified the `yb-cleanup` container's command to make it compatible with OpenShift.

### Test Plan

Deployed the YB on Openshift and populated the Northwind database.
Here is the screenshot of `yb-cleanup` logs & log directory:
```sh
Compressing file /home/yugabyte/tserver/logs/yb-tserver.yb-tserver-2.1000610000.log.INFO.20201215-165403.1
Compressing file /home/yugabyte/tserver/logs/yb-tserver.yb-tserver-2.1000610000.log.ERROR.20201215-165408.1
Compressing file /home/yugabyte/tserver/logs/yb-tserver.yb-tserver-2.1000610000.log.WARNING.20201215-165403.1
Permitted disk usage for yb-tserver*log.* files in kb: 6683288
Disk usage by yb-tserver*log.* files in kb: 5140
Permitted disk usage for postgres*log* files in kb: 100000
Disk usage by postgres*log* files in kb: 0
Compressing file /home/yugabyte/tserver/logs/postgresql-2020-12-15_165404.log
Compressing file /home/yugabyte/tserver/logs/yb-tserver.yb-tserver-2.1000610000.log.INFO.20201215-170215.1
Compressing file /home/yugabyte/tserver/logs/yb-tserver.yb-tserver-2.1000610000.log.ERROR.20201215-170220.1
Compressing file /home/yugabyte/tserver/logs/yb-tserver.yb-tserver-2.1000610000.log.WARNING.20201215-170215.1
Permitted disk usage for yb-tserver*log.* files in kb: 6683288
Disk usage by yb-tserver*log.* files in kb: 17286
Permitted disk usage for postgres*log* files in kb: 100000
Disk usage by postgres*log* files in kb: 1
```

```sh
~ $ ls -l /home/yugabyte/tserver/logs/
total 16976
-rw-r-----    1 10006100 10006100       299 Dec 15 17:14 postgresql-2020-12-15_165404.log.gz
-rw-------    1 10006100 10006100       875 Dec 15 17:09 postgresql-2020-12-15_170926.log
lrwxrwxrwx    1 10006100 10006100        62 Dec 15 17:09 yb-tserver.ERROR -> yb-tserver.yb-tserver-2.1000610000.log.ERROR.20201215-170931.1
lrwxrwxrwx    1 10006100 10006100        61 Dec 15 17:09 yb-tserver.INFO -> yb-tserver.yb-tserver-2.1000610000.log.INFO.20201215-170926.1
lrwxrwxrwx    1 10006100 10006100        64 Dec 15 17:09 yb-tserver.WARNING -> yb-tserver.yb-tserver-2.1000610000.log.WARNING.20201215-170926.1
-rw-rw-r--    1 10006100 10006100       901 Dec 15 17:07 yb-tserver.yb-tserver-2.1000610000.log.ERROR.20201215-165408.1.gz
-rw-r--r--    1 10006100 10006100       761 Dec 15 17:14 yb-tserver.yb-tserver-2.1000610000.log.ERROR.20201215-170220.1.gz
-rw-r--r--    1 10006100 10006100      6501 Dec 15 17:10 yb-tserver.yb-tserver-2.1000610000.log.ERROR.20201215-170931.1
-rw-rw-r--    1 10006100 10006100     86299 Dec 15 17:07 yb-tserver.yb-tserver-2.1000610000.log.INFO.20201215-165403.1.gz
-rw-r--r--    1 10006100 10006100    160969 Dec 15 17:14 yb-tserver.yb-tserver-2.1000610000.log.INFO.20201215-170215.1.gz
-rw-r--r--    1 10006100 10006100  16425992 Dec 15 17:14 yb-tserver.yb-tserver-2.1000610000.log.INFO.20201215-170926.1
-rw-rw-r--    1 10006100 10006100     48485 Dec 15 17:07 yb-tserver.yb-tserver-2.1000610000.log.WARNING.20201215-165403.1.gz
-rw-r--r--    1 10006100 10006100     68991 Dec 15 17:14 yb-tserver.yb-tserver-2.1000610000.log.WARNING.20201215-170215.1.gz
-rw-r--r--    1 10006100 10006100    538219 Dec 15 17:13 yb-tserver.yb-tserver-2.1000610000.log.WARNING.20201215-170926.1
```

Fixes https://github.com/yugabyte/yugabyte-db/issues/6524