### PR TITLE
Modified to deploy multiple YB clusters in the single namespace

### DIFF
--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -3,26 +3,64 @@
 Expand the name of the chart.
 */}}
 {{- define "yugabyte.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 43 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
+The components in this chart create additional resources that expand the longest created name strings.
+The longest name that gets created of 20 characters, so truncation should be 63-20=43.
 */}}
 {{- define "yugabyte.fullname" -}}
 {{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Values.fullnameOverride | trunc 43 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- .Release.Name | trunc 43 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 43 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Generate common labels */}}
+{{- define "yugabyte.labels" }}
+heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
+release: {{ .Release.Name | quote }}
+chart: {{ .Values.oldNamingStyle | ternary .Chart.Name (include "yugabyte.chart" .) | quote }}
+component: {{ .Values.Component | quote }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}
+
+{{/* Generate app label */}}
+{{- define "yugabyte.applabel" }}
+{{- if .root.Values.oldNamingStyle }}
+app: "{{ .label }}"
+{{- else }}
+app.kubernetes.io/name: "{{ .label }}"
+{{- end }}
+{{- end }}
+
+{{/* Generate app selector */}}
+{{- define "yugabyte.appselector" }}
+{{- if .root.Values.oldNamingStyle }}
+app: "{{ .label }}"
+{{- else }}
+app.kubernetes.io/name: "{{ .label }}"
+release: {{ .root.Release.Name | quote }}
+{{- end }}
+{{- end }}
+
+{{/* Create Volume name */}}
+{{- define "yugabyte.volume_name" -}}
+{{- printf "%s-datadir" (include "yugabyte.fullname" .) -}}
+{{- end -}}
+
 {{/*
 Derive the memory hard limit for each POD based on the memory limit.
 Since the memory is represented in <x>GBi, we use this function to convert that into bytes.
@@ -52,9 +90,14 @@ Create chart name and version as used by the chart label.
 {{- define "yugabyte.master_addresses" -}}
 {{- $master_replicas := .Values.replicas.master | int -}}
 {{- $domain_name := .Values.domainName -}}
+{{- $prefix := (include "yugabyte.fullname" .)  -}}
   {{- range .Values.Services }}
     {{- if eq .name "yb-masters" }}
+      {{- if $.Values.oldNamingStyle }}
       {{range $index := until $master_replicas }}{{if ne $index 0}},{{end}}yb-master-{{ $index }}.yb-masters.$(NAMESPACE).svc.{{ $domain_name }}:7100{{end}}
+      {{- else }}
+      {{range $index := until $master_replicas }}{{if ne $index 0}},{{end}}{{- $prefix }}-yb-master-{{ $index }}.{{- $prefix }}-yb-masters.$(NAMESPACE).svc.{{ $domain_name }}:7100{{end}}
+      {{- end }}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/stable/yugabyte/templates/master-servicemonitor.yaml
+++ b/stable/yugabyte/templates/master-servicemonitor.yaml
@@ -4,7 +4,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "yugabyte.fullname" . }}-yb-master
   labels:
+    {{- if .Values.oldNamingStyle }}
     app: "yb-master"
+    {{- else }}
+    app.kubernetes.io/name: "yb-master"
+    {{- end }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     component: "{{ .Values.Component }}"
@@ -15,7 +19,11 @@ spec:
   jobLabel: "release"
   selector:
     matchLabels:
+      {{- if .Values.oldNamingStyle }}
       app: "yb-master"
+      {{- else }}
+      app.kubernetes.io/name: "yb-master"
+      {{- end }}
       release: {{ .Release.Name | quote }}
       service-type: "headless"
   endpoints:

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -5,13 +5,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: yugabyte-tls-client-cert
+  name: {{ $root.Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" $root)) }}
   namespace: "{{ $root.Release.Namespace }}"
   labels:
-    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-    release: {{ $root.Release.Name | quote }}
-    chart: "{{ $root.Chart.Name }}"
-    component: "{{ $root.Values.Component }}"
+    {{- include "yugabyte.labels" $root | indent 4 }}
 type: Opaque
 data:
 {{- $rootCAClient := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}
@@ -24,26 +21,26 @@ data:
 
 {{- range .Values.Services }}
 {{- $service := . -}}
+{{- $appLabelArgs := dict "label" .label "root" $root -}}
 
 {{- if $root.Values.tls.enabled }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $service.label }}-yugabyte-tls-cert
+  name: {{ $root.Values.oldNamingStyle | ternary (printf "%s-yugabyte-tls-cert" $service.label) (printf "%s-%s-tls-cert" (include "yugabyte.fullname" $root) $service.label) }}
   namespace: "{{ $root.Release.Namespace }}"
   labels:
-    app: "{{ $service.label }}"
-    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-    release: {{ $root.Release.Name | quote }}
-    chart: "{{ $root.Chart.Name }}"
-    component: "{{ $root.Values.Component }}"
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- include "yugabyte.labels" $root | indent 4 }}
 type: Opaque
 data:
 {{- $rootCA := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}
 {{- $replicas := (eq .name "yb-masters") | ternary $root.Values.replicas.master $root.Values.replicas.tserver -}}
 {{- range $index := until ( int ( $replicas ) ) }}
-{{- $node := printf "%s-%d.%s.%s.svc.%s" $service.label $index $service.name $root.Release.Namespace $root.Values.domainName }}
+{{- $nodeOldStyle := printf "%s-%d.%s.%s.svc.%s" $service.label $index $service.name $root.Release.Namespace $root.Values.domainName }}
+{{- $nodeNewStyle := printf "%s-%s-%d.%s-%s.%s.svc.%s" (include "yugabyte.fullname" $root) $service.label $index (include "yugabyte.fullname" $root) $service.name $root.Release.Namespace $root.Values.domainName }}
+{{- $node := $root.Values.oldNamingStyle | ternary $nodeOldStyle $nodeNewStyle }}
 {{- $dns1 := printf "*.*.%s" $root.Release.Namespace }}
 {{- $dns2 := printf "%s.svc.%s" $dns1 $root.Values.domainName }}
 {{- $server := genSignedCert $node ( default nil ) (list $dns1 $dns2 ) 3650 $rootCA }}
@@ -57,13 +54,10 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .name }}"
+  name: {{ $root.Values.oldNamingStyle | ternary .name (printf "%s-%s" (include "yugabyte.fullname" $root) .name) | quote }}
   labels:
-    app: "{{ .label }}"
-    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-    release: {{ $root.Release.Name | quote }}
-    chart: "{{ $root.Chart.Name }}"
-    component: "{{ $root.Values.Component }}"
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- include "yugabyte.labels" $root | indent 4 }}
     service-type: "headless"
 spec:
   clusterIP: None
@@ -73,7 +67,7 @@ spec:
       port: {{ $port }}
     {{- end}}
   selector:
-    app: "{{ .label }}"
+    {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
 
 {{ if $root.Values.enableLoadBalancer }}
 {{- range $endpoint :=  $root.Values.serviceEndpoints }}
@@ -82,15 +76,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ $endpoint.name }}"
+  name: {{ $root.Values.oldNamingStyle | ternary $endpoint.name (printf "%s-%s" (include "yugabyte.fullname" $root) $endpoint.name) | quote }}
   annotations:
 {{ toYaml $endpoint.annotations | indent 4 }}
   labels:
-    app: "{{ $endpoint.app }}"
-    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-    release: {{ $root.Release.Name | quote }}
-    chart: "{{ $root.Chart.Name }}"
-    component: "{{ $root.Values.Component }}"
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- include "yugabyte.labels" $root | indent 4 }}
 spec:
   {{ if eq $root.Release.Service "Tiller" }}
   clusterIP:
@@ -105,7 +96,7 @@ spec:
       port: {{ $port }}
     {{- end}}
   selector:
-    app: "{{ $endpoint.app }}"
+    {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
   type: {{ $endpoint.type }}
 {{- end}}
 {{- end}}
@@ -115,16 +106,13 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "{{ .label }}"
+  name: {{ $root.Values.oldNamingStyle | ternary .label (printf "%s-%s" (include "yugabyte.fullname" $root) .label) | quote }}
   namespace: "{{ $root.Release.Namespace }}"
   labels:
-    app: "{{ .label }}"
-    heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-    release: {{ $root.Release.Name | quote }}
-    chart: "{{ $root.Chart.Name }}"
-    component: "{{ $root.Values.Component }}"
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- include "yugabyte.labels" $root | indent 4 }}
 spec:
-  serviceName: "{{ .name }}"
+  serviceName: {{ $root.Values.oldNamingStyle | ternary .name (printf "%s-%s" (include "yugabyte.fullname" $root) .name) | quote }}
   podManagementPolicy: {{ $root.Values.PodManagementPolicy }}
   {{ if eq .name "yb-masters" }}
   replicas: {{ $root.Values.replicas.master }}
@@ -136,14 +124,11 @@ spec:
   volumeClaimTemplates:
     {{- range $index := until (int ($storageInfo.count )) }}
     - metadata:
-        name: datadir{{ $index }}
+        name: {{ $root.Values.oldNamingStyle | ternary (printf "datadir%d" $index) (printf "%s%d" (include "yugabyte.volume_name" $root) $index) }}
         annotations:
           volume.beta.kubernetes.io/storage-class: {{ $storageInfo.storageClass }}
         labels:
-          heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-          release: {{ $root.Release.Name | quote }}
-          chart: "{{ $root.Chart.Name }}"
-          component: "{{ $root.Values.Component }}"
+          {{- include "yugabyte.labels" $root | indent 10 }}
       spec:
         accessModes:
           - "ReadWriteOnce"
@@ -165,7 +150,7 @@ spec:
       {{ end }}
   selector:
     matchLabels:
-      app: "{{ .label }}"
+      {{- include "yugabyte.appselector" ($appLabelArgs) | indent 6 }}
   template:
     metadata:
       {{ if $root.Values.networkAnnotation }}
@@ -173,11 +158,8 @@ spec:
 {{ toYaml $root.Values.networkAnnotation | indent 8}}
       {{ end }}
       labels:
-        app: "{{ .label }}"
-        heritage: {{ $root.Values.helm2Legacy | ternary "Tiller" ($root.Release.Service | quote) }}
-        release: {{ $root.Release.Name | quote }}
-        chart: "{{ $root.Chart.Name }}"
-        component: "{{ $root.Values.Component }}"
+        {{- include "yugabyte.applabel" ($appLabelArgs) | indent 8 }}
+        {{- include "yugabyte.labels" $root | indent 8 }}
     spec:
       {{- if $root.Values.Image.pullSecretName }}
       imagePullSecrets:
@@ -205,10 +187,21 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
+                {{- if $root.Values.oldNamingStyle }}
                 - key: app
                   operator: In
                   values:
                   - "{{ .label }}"
+                {{- else }}
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - "{{ .label }}"
+                - key: release
+                  operator: In
+                  values:
+                  - {{ $root.Release.Name | quote }}
+                {{- end }}
               topologyKey: kubernetes.io/hostname
       containers:
       - name: "{{ .label }}"
@@ -263,9 +256,17 @@ spec:
           {{- if $root.Values.istioCompatibility.enabled }}
           - "--rpc_bind_addresses=0.0.0.0:7100"
           {{- else }}
+          {{- if $root.Values.oldNamingStyle }}
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          {{- else }}
+          - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s-%s.$(NAMESPACE).svc.%s" (include "yugabyte.fullname" $root) .name $root.Values.domainName }}"
           {{- end }}
+          {{- end }}
+          {{- if $root.Values.oldNamingStyle }}
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:7100"
+          {{- else }}
+          - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s-%s.$(NAMESPACE).svc.%s" (include "yugabyte.fullname" $root) .name $root.Values.domainName }}:7100"
+          {{- end }}
           - "--webserver_interface={{ eq $root.Values.ip_version_support "v6_only" | ternary "[::]" "0.0.0.0" }}"
           {{ if eq $root.Values.ip_version_support "v6_only"}}
           - "--net_address_filter=ipv6_external,ipv6_non_link_local,ipv6_all,ipv4_external,ipv4_all"
@@ -298,16 +299,28 @@ spec:
         {{ else }}
           - "/home/yugabyte/bin/yb-tserver"
           - "--fs_data_dirs={{ template "yugabyte.fs_data_dirs" $storageInfo }}"
+          {{- if $root.Values.oldNamingStyle }}
           - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}:9100"
+          {{- else }}
+          - "--server_broadcast_addresses={{ printf "$(HOSTNAME).%s-%s.$(NAMESPACE).svc.%s" (include "yugabyte.fullname" $root) .name $root.Values.domainName }}:9100"
+          {{- end }}
           {{- if $root.Values.istioCompatibility.enabled }}
           - "--rpc_bind_addresses=0.0.0.0:9100"
           {{- else }}
+          {{- if $root.Values.oldNamingStyle }}
           - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          {{- else }}
+          - "--rpc_bind_addresses={{ printf "$(HOSTNAME).%s-%s.$(NAMESPACE).svc.%s" (include "yugabyte.fullname" $root) .name $root.Values.domainName }}"
+          {{- end }}
           {{- end }}
           {{- if $root.Values.istioCompatibility.enabled }}
           - "--cql_proxy_bind_address=0.0.0.0:9042"
           {{- else }}
+          {{- if $root.Values.oldNamingStyle }}
           - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .name $root.Values.domainName }}"
+          {{- else }}
+          - "--cql_proxy_bind_address={{ printf "$(HOSTNAME).%s-%s.$(NAMESPACE).svc.%s" (include "yugabyte.fullname" $root) .name $root.Values.domainName }}"
+          {{- end }}
           {{- end }}
           - "--webserver_interface={{ eq $root.Values.ip_version_support "v6_only" | ternary "[::]" "0.0.0.0" }}"
           {{ if eq $root.Values.ip_version_support "v6_only" }}
@@ -354,15 +367,15 @@ spec:
         volumeMounts:
           {{ if not $root.Values.storage.ephemeral }}
           {{- range $index := until (int ($storageInfo.count)) }}
-          - name: datadir{{ $index }}
+          - name: {{ $root.Values.oldNamingStyle | ternary (printf "datadir%d" $index) (printf "%s%d" (include "yugabyte.volume_name" $root) $index) }}
             mountPath: /mnt/disk{{ $index }}
           {{- end }}
           {{- end }}
           {{- if $root.Values.tls.enabled }}
-          - name: {{ .label }}-yugabyte-tls-cert
+          - name: {{ $root.Values.oldNamingStyle | ternary (printf "%s-yugabyte-tls-cert" .label) (printf "%s-%s-tls-cert" (include "yugabyte.fullname" $root) .label) }}
             mountPath: /opt/certs/yugabyte
             readOnly: true
-          - name: yugabyte-tls-client-cert
+          - name: {{ $root.Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" $root)) }}
             mountPath: /root/.yugabytedb/
             readOnly: true
           {{- end }}
@@ -385,7 +398,7 @@ spec:
               sleep 86400;
             done
         volumeMounts:
-          - name: datadir0
+          - name: {{ $root.Values.oldNamingStyle | ternary "datadir0" (printf "%s0" (include "yugabyte.volume_name" $root)) }}
             mountPath: /home/yugabyte/
             subPath: yb-data
       {{- end }}
@@ -393,19 +406,19 @@ spec:
       volumes:
         {{ if not $root.Values.storage.ephemeral }}
         {{- range $index := until (int ($storageInfo.count)) }}
-        - name: datadir{{ $index }}
+        - name: {{ $root.Values.oldNamingStyle | ternary (printf "datadir%d" $index) (printf "%s%d" (include "yugabyte.volume_name" $root) $index) }}
           hostPath:
             path: /mnt/disks/ssd{{ $index }}
         {{- end }}
         {{- end }}
         {{- if $root.Values.tls.enabled }}
-        - name: {{ .label }}-yugabyte-tls-cert
+        - name: {{ $root.Values.oldNamingStyle | ternary (printf "%s-yugabyte-tls-cert" .label) (printf "%s-%s-tls-cert" (include "yugabyte.fullname" $root) .label) }}
           secret:
-            secretName: {{ .label }}-yugabyte-tls-cert
+            secretName: {{ $root.Values.oldNamingStyle | ternary (printf "%s-yugabyte-tls-cert" .label) (printf "%s-%s-tls-cert" (include "yugabyte.fullname" $root) .label) }}
             defaultMode: 256
-        - name: yugabyte-tls-client-cert
+        - name: {{ $root.Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" $root)) }}
           secret:
-            secretName: yugabyte-tls-client-cert
+            secretName: {{ $root.Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" $root)) }}
             defaultMode: 256
         {{- end }}
 {{- if eq $root.Values.isMultiAz false }}
@@ -413,11 +426,11 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ .label }}-pdb
+  name: {{ $root.Values.oldNamingStyle | ternary (printf "%s-pdb" .label) (printf "%s-%s-pdb" (include "yugabyte.fullname" $root) .name) }}
 spec:
   maxUnavailable: {{ template "yugabyte.max_unavailable_for_quorum" $root }}
   selector:
     matchLabels:
-      app: {{ .label }}
+      {{- include "yugabyte.appselector" ($appLabelArgs) | indent 6 }}
 {{- end }}
 {{- end }}

--- a/stable/yugabyte/templates/tserver-servicemonitor.yaml
+++ b/stable/yugabyte/templates/tserver-servicemonitor.yaml
@@ -5,7 +5,11 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "yugabyte.fullname" . }}-yb-tserver
   labels:
+    {{- if .Values.oldNamingStyle }}
     app: "yb-tserver"
+    {{- else }}
+    app.kubernetes.io/name: "yb-tserver"
+    {{- end }}
     release: {{ .Release.Name | quote }}
     chart: "{{ .Chart.Name }}"
     component: "{{ .Values.Component }}"
@@ -16,7 +20,11 @@ spec:
   jobLabel: "release"
   selector:
     matchLabels:
+      {{- if .Values.oldNamingStyle }}
       app: "yb-tserver"
+      {{- else }}
+      app.kubernetes.io/name: "yb-tserver"
+      {{- end }}
       release: {{ .Release.Name | quote }}
       service-type: "headless"
   endpoints:

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -196,3 +196,5 @@ authCredentials:
     user: ""
     password: ""
     keyspace: ""
+
+oldNamingStyle: true


### PR DESCRIPTION
### Summary

- Modified the Helm charts for multiple YB deployments in the single namespace.
- Now Helm Charts have two naming conventions, the old naming convention will be used by default, and to tweak the naming convention for the deployment of multiple YB clusters in the single namespace use `oldNamingStyle: false` or  `--set oldNamingStyle=false`.
- Migration won't possible for the old naming convention to the new naming convention due to `volumeClaimTemplates` because it creates the PVC every time whenever it gets a new combination of `given name + pod name`.

### Test Plan:

The following test scenarios have been tested so far.
**Test Environment:** OpenShift and GKE, `ysqlsh` with Northwind DB, and tested externally through EC2 instance.

1. Created a YB cluster with the old naming convention, upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image, and at last, upgraded with TLS flag. 
2. Created 2 YB clusters with the new naming convention, upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image, and at last, upgraded with TLS flag. 
3. Created a YB cluster with the new naming convention, upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image, and then upgraded with TLS flag but with the wrong path of certs to test rollback. And at last, after rollback, again upgraded with TLS flag.
4. Created a YB cluster using charts hosted on `charts.yugabyte.com`, upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image using these changes (keeping `oldNamingStyle: true`), and at last, upgraded with TLS flag. 
5. Created a YB cluster using charts hosted on `charts.yugabyte.com`, and try to upgrade without any change using these changes (keeping `oldNamingStyle: true`). And as expected, the pods haven't restarted.
6. Created a YB cluster with ServiceMonitor using charts hosted on `charts.yugabyte.com`, upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image using these changes (keeping `oldNamingStyle: true`), and at last, upgraded with TLS flag. 
7. Created a YB cluster with ServiceMonitor (With 53 Characters Release name) using charts hosted on `charts.yugabyte.com`, upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image using these changes (keeping `oldNamingStyle: true`), so the changes will remove the old SM and deploy the new SM using the new naming convention because previously `_helpers.tpl` trimming the 63 characters but now it is 43 characters. And throughout the upgrading process pod won't restart because we aren't upgrading the naming convention for pods.
8. Created a YB cluster with ServiceMonitor (new naming convention), upgraded with the `quay.io/yugabyte/yugabyte-itest:2.5.1.0-b90` image, and at last, upgraded with TLS flag. 

fixes https://github.com/yugabyte/yugabyte-db/issues/6355