### PR TITLE
[#6553] Platform: Use default config from reference.conf in production

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -67,8 +67,6 @@ data:
       health.default_email = "{{ .Values.yugaware.health.email }}"
       health.ses_email_username = "{{ .Values.yugaware.health.username }}"
       health.ses_email_password = "{{ .Values.yugaware.health.password }}"
-      taskGC.gc_check_interval = 1 day
-      taskGC.task_retention_duration = 30 days
     }
 
     play.filters {


### PR DESCRIPTION
Now we have a better config sharing mechanism so no need of overrides.
The reference config has correct value (120 days) for retention period.

Related changes:
YW: https://phabricator.dev.yugabyte.com/D10247
DevOps: https://phabricator.dev.yugabyte.com/D10248
