### PR TITLE
[YW] Removed nginx proxy_pass rules 

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -151,17 +151,6 @@ data:
       location / {
         proxy_pass http://{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9000;
       }
-
-      location ~ "^/proxy/(.*.svc.cluster.local):([0-9]{4,6})/(.*)$" {
-        resolver {{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:53" "127.0.0.1:5353 ipv6=off"  }};
-        proxy_pass "http://$1:$2/$3$is_args$args";
-        sub_filter "http://" "/proxy/";
-        sub_filter "href='/" "href='/proxy/$1:$2/";
-        sub_filter "href=\"/" "href=\"/proxy/$1:$2/";
-        sub_filter "src='/" "src='/proxy/$1:$2/";
-        sub_filter "src=\"/" "src=\"/proxy/$1:$2/";
-        sub_filter_once off;
-      }
     }
 ---
 apiVersion: v1

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -227,10 +227,3 @@ spec:
             mountPath: /opt/certs/
             readOnly: true
           {{- end }}
-        - name: dnsmasq
-          image: {{ include "full_image" (dict "containerName" "dnsmasq" "root" .) }}
-          args:
-            - --listen
-            - "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]:5353"  "127.0.0.1:5353" }}"
-            - --enable-search
-            - --hostsfile=/etc/hosts

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -33,11 +33,6 @@ image:
     tag: 1.17.4-amd64
     name: nginxinc/nginx-unprivileged
 
-  dnsmasq:
-    registry: ""
-    tag: release-1.0.7
-    name: janeczku/go-dnsmasq
-
 yugaware:
   replicas: 1
   storage: 100Gi


### PR DESCRIPTION
### Summary:
Removed the Nginx proxy pass rules from `config.yaml` and dnsmasq from STS.

### Test Plan:
**Test condition:** Using `<YW-Service>/proxy/<Master:7000>/` should not open the YB master UI in the private browser window.

1. Deploy the YW from current helm charts (Branch: master) and created a YB Cluster. The test is failing then upgraded the YW with the changes and the test is successfully passed.
2. Deploy a YW from the changes and created a YB cluster. And the test passed.

fixes https://github.com/yugabyte/yugabyte-db/issues/6813