### PR TITLE
[YB] Replaced the busybox image with YB image

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -369,7 +369,8 @@ spec:
 
       {{ if not $root.Values.storage.ephemeral }}
       - name: yb-cleanup
-        image: busybox:1.31
+        image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
+        imagePullPolicy: {{ $root.Values.Image.pullPolicy }}
         env:
         - name: USER
           value: "yugabyte"


### PR DESCRIPTION
### Summary

- Replaced the `busybox` image for the `yb-cleanup` container to the YB image.

### Test Plan

- Only the `yb-cleanup` container image has been updated in the diff of helm's dry run.
- Deployed the YB using changes on OCP & it's working fine.

fixes: https://github.com/yugabyte/yugabyte-db/issues/6964