### PR TITLE
Add RBAC files for different deployment strategies

### DIFF
--- a/rbac/README.md
+++ b/rbac/README.md
@@ -1,0 +1,88 @@
+## RBAC resources for Yugabyte Platform
+
+This directory contains different RBAC manifests containing Roles,
+RoleBindings etc required to create YugabyteDB universes using
+Yugabyte Platform.
+
+### 0. yugabyte-platform-universe-management-sa.yaml (required)
+This is the ServiceAccount whose secret can be used to generate a
+kubeconfig. This should ideally be created in a namespace where your
+are going to install the platform software. It can be created in any
+other namespace as well, it should not be deleted once it is being
+used by the platform.
+
+Make sure you replace the `[yb-platform]` from the following command
+with correct namespace for the ServiceAccount.
+
+```console
+kubectl create ns [yb-platform]
+kubectl apply -n [yb-platform] -f yugabyte-platform-universe-management-sa.yaml
+```
+
+Once the ServiceAccount is created, you can follow any one of the
+following steps depending to your requirements.
+
+### a. platform-global.yaml
+Grants access to only the specific cluster roles to create and manage
+YugabyteDB universes across all the namespaces in a cluster. Contains
+ClusterRoles and ClusterRoleBindings for the required set of
+permissions.
+
+Make sure you replace the `[yb-platform]` from the following command
+with correct namespace of the ServiceAccount (from the step 0).
+
+```console
+cat platform-global.yaml \
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: [yb-platform]"/g \
+  | kubectl apply -f -
+```
+
+### b. platform-global-admin.yaml
+Grants broad cluster level admin access.
+
+Make sure you replace the `[yb-platform]` from the following command
+with correct namespace of the ServiceAccount (from the step 0).
+
+```console
+cat platform-global-admin.yaml \
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: [yb-platform]"/g \
+  | kubectl apply -f -
+```
+
+### c. platform-namespaced.yaml
+Grants access to only the specific roles required to create and manage
+YugabyteDB universes in a particular namespace only. Contains Roles
+and RoleBindings for the required set of permissions.
+
+Example: You want to allow platform software to manage YugabyteDB
+universes in the namespaces `yb-db-trial` and `yb-db-us-east4-a` (the
+target namespaces). In this case you will apply
+`platform-namespaced.yaml` in both the target namespaces.
+
+- Make sure you replace the `[yb-platform]` from the following command
+  with correct namespace of the ServiceAccount (from the step 0).
+- Specify the target namespace using `-n`. i.e. replace
+  `[yb-db-trial]` with correct value.
+
+```console
+cat platform-namespaced.yaml \
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: [yb-platform]"/g \
+  | kubectl apply -n [yb-db-trial] -f -
+```
+
+### d. platform-namespaced-admin.yaml
+Grants namespace level admin access.
+
+Similar to (c), if you have multiple target namespaces, then you will
+have to apply the YAML mulitple times in those target namespaces.
+
+- Make sure you replace the `[yb-platform]` from the following command
+  with correct namespace of the ServiceAccount (from the step 0).
+- Specify the target namespace using `-n`. i.e. replace
+  `[yb-db-trial]` with correct value.
+
+```console
+cat platform-namespaced-admin.yaml \
+  | sed "s/namespace: <SA_NAMESPACE>/namespace: [yb-platform]"/g \
+  | kubectl apply -n [yb-db-trial] -f -
+```

--- a/rbac/platform-global-admin.yaml
+++ b/rbac/platform-global-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: yugabyte-platform-global-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: yugabyte-platform-universe-management
+    namespace: <SA_NAMESPACE>

--- a/rbac/platform-global.yaml
+++ b/rbac/platform-global.yaml
@@ -1,0 +1,133 @@
+# yugabyte-helm-operations role has set of permissions required to
+# install, upgrade, delete the yugabyte chart.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: yugabyte-helm-operations
+rules:
+- apiGroups:
+  - "policy"
+  resources:
+  - "poddisruptionbudgets"
+  verbs:
+  - "get"
+  - "create"
+  - "delete"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+  - "delete"
+  - "create"
+  - "patch"
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets"
+  verbs:
+  - "get"
+  - "delete"
+  - "create"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "create"
+  - "list"                      # needed by Helm
+  - "get"
+  - "delete"
+  - "update"                    # needed by Helm
+  - "patch"
+## We don't use ServiceMonitor in platform
+# - apiGroups:
+#   - "monitoring.coreos.com"
+#   resources:
+#   - "servicemonitors"
+#   verbs:
+#   - "get"
+#   - "delete"
+#   - "create"
+#   - "patch"
+---
+
+# yugabyte-management role has set of permissions required by
+# platform software to manage YugabyteDB universes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: yugabyte-management
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  verbs:
+  - "delete"
+  - "create"
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "get"                       # required for single pod
+  - "list"                      # required for get pods
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+  - "list"                      # required for label selectors
+- apiGroups:
+  - ""
+  resources:
+  - "persistentvolumeclaims"
+  verbs:
+  - "list"                      # required for label selectors
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/exec"
+  verbs:
+  - "create"                      # required for exec and cp
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets/scale"
+  verbs:
+  - "patch"                     # required for scale command
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yugabyte-helm-operations
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: yugabyte-helm-operations
+subjects:
+  - kind: ServiceAccount
+    name: yugabyte-platform-universe-management
+    namespace: <SA_NAMESPACE>
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yugabyte-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: yugabyte-management
+subjects:
+  - kind: ServiceAccount
+    name: yugabyte-platform-universe-management
+    namespace: <SA_NAMESPACE>
+---

--- a/rbac/platform-namespaced-admin.yaml
+++ b/rbac/platform-namespaced-admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: yugabyte-platform-global-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: yugabyte-platform-universe-management
+    namespace: <SA_NAMESPACE>

--- a/rbac/platform-namespaced.yaml
+++ b/rbac/platform-namespaced.yaml
@@ -1,0 +1,133 @@
+# yugabyte-helm-operations role has set of permissions required to
+# install, upgrade, delete the yugabyte chart.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yugabyte-helm-operations
+rules:
+- apiGroups:
+  - "policy"
+  resources:
+  - "poddisruptionbudgets"
+  verbs:
+  - "get"
+  - "create"
+  - "delete"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+  - "delete"
+  - "create"
+  - "patch"
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets"
+  verbs:
+  - "get"
+  - "delete"
+  - "create"
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "create"
+  - "list"                      # needed by Helm
+  - "get"
+  - "delete"
+  - "update"                    # needed by Helm
+  - "patch"
+## We don't use ServiceMonitor in platform
+# - apiGroups:
+#   - "monitoring.coreos.com"
+#   resources:
+#   - "servicemonitors"
+#   verbs:
+#   - "get"
+#   - "delete"
+#   - "create"
+#   - "patch"
+---
+
+# yugabyte-management role has set of permissions required by
+# platform software to manage YugabyteDB universes.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yugabyte-management
+rules:
+# - apiGroups:
+#   - ""
+#   resources:
+#   - "namespaces"
+#   verbs:
+#   - "delete"
+#   - "create"
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "get"                       # required for single pod
+  - "list"                      # required for get pods
+- apiGroups:
+  - ""
+  resources:
+  - "services"
+  verbs:
+  - "get"
+  - "list"                      # required for label selectors
+- apiGroups:
+  - ""
+  resources:
+  - "persistentvolumeclaims"
+  verbs:
+  - "list"                      # required for label selectors
+  - "delete"
+- apiGroups:
+  - ""
+  resources:
+  - "pods/exec"
+  verbs:
+  - "create"                      # required for exec and cp
+- apiGroups:
+  - "apps"
+  resources:
+  - "statefulsets/scale"
+  verbs:
+  - "patch"                     # required for scale command
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yugabyte-helm-operations
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yugabyte-helm-operations
+subjects:
+  - kind: ServiceAccount
+    name: yugabyte-platform-universe-management
+    namespace: <SA_NAMESPACE>
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yugabyte-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yugabyte-management
+subjects:
+  - kind: ServiceAccount
+    name: yugabyte-platform-universe-management
+    namespace: <SA_NAMESPACE>
+---

--- a/rbac/yugabyte-platform-universe-management-sa.yaml
+++ b/rbac/yugabyte-platform-universe-management-sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yugabyte-platform-universe-management
+  # namespace: kube-system
+---


### PR DESCRIPTION
Related to https://github.com/yugabyte/yugabyte-db/issues/6348

Scenarios tested:
- Created a new providers with kubeconfig created using
  platform-global.yaml and platform-namespaced.yaml.
- Tried creating a new universe, edited it (changed number of nodes),
  took backup, deleted the universe.
- All the above operations worked just fine.
