### PR TITLE
[#7098]: Split TLS flags for internal/external connections.

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -293,7 +293,7 @@ spec:
           {{- end}}
           {{ if $root.Values.tls.enabled }}
           - "--certs_dir=/opt/certs/yugabyte"
-          - "--use_node_to_node_encryption=true"
+          - "--use_node_to_node_encryption={{ $root.Values.tls.nodeToNode }}"
           - "--allow_insecure_connections={{ $root.Values.tls.insecure }}"
           {{- end }}
         {{ else }}
@@ -357,9 +357,9 @@ spec:
           {{- end }}
           {{ if $root.Values.tls.enabled }}
           - "--certs_dir=/opt/certs/yugabyte"
-          - "--use_node_to_node_encryption=true"
+          - "--use_node_to_node_encryption={{ $root.Values.tls.nodeToNode }}"
           - "--allow_insecure_connections={{ $root.Values.tls.insecure }}"
-          - "--use_client_to_server_encryption=true"
+          - "--use_client_to_server_encryption={{ $root.Values.tls.clientToServer }}"
           - "--certs_for_client_dir=/opt/certs/yugabyte"
           {{- end }}
         {{ end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -45,6 +45,8 @@ partition:
 tls:
   # Set to true to enable the TLS.
   enabled: false
+  nodeToNode: true
+  clientToServer: true
   # Set to false to disallow any service with unencrypted communication from joining this cluster
   insecure: false
   rootCA:


### PR DESCRIPTION
Summary:
Currently the helm chart always enabled both client-to-server and node-to-node TLS for
encryption, even though we explicitly want to de-couple the two. This diff adds additional flags to
take care of that.

Test Plan:
Ran helm install after tweaking each flag, and ensured that the servers came up with just
the correct flag set.

Reviewers: jvigil, sanketh

Reviewed By: sanketh

Subscribers: yugaware

Differential Revision: https://phabricator.dev.yugabyte.com/D10672