### PR TITLE
[YCQL] Added env var for ycqlsh to connect the TLS secured cluster

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -234,6 +234,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if and $root.Values.tls.enabled $root.Values.tls.clientToServer (ne .name "yb-masters") }}
+        - name: SSL_CERTFILE
+          value: /root/.yugabytedb/root.crt
+        {{- end }}
         resources:
         {{ if eq .name "yb-masters" }}
 {{ toYaml $root.Values.resource.master | indent 10 }}


### PR DESCRIPTION
### Summary

After these changes, `ycqlsh` can connect from inside the pod to TLS secured cluster.

### Test Plan
- `ycqlsh` able to connect the TLS secured YB cluster within the pod.