### PR TITLE
[Platform] Use OpenShift's Prometheus for container related metrics

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -175,6 +175,50 @@ data:
         scrape_interval:     10s
         evaluation_interval: 10s
     scrape_configs:
+      {{- if .Values.ocpCompatibility.enabled }}
+      - job_name: "ocp-prometheus-federated"
+        scheme: https
+
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+        honor_labels: true
+        metrics_path: "/federate"
+
+        params:
+          'match[]':
+            # kubelet metrics
+            - 'kubelet_volume_stats_used_bytes{persistentvolumeclaim=~"(.*)-yb-(.*)"}'
+            - 'kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"(.*)-yb-(.*)"}'
+            # kubelet cadvisor metrics
+            - 'container_cpu_usage_seconds_total{pod=~"(.*)yb-(.*)"}'
+            - 'container_memory_working_set_bytes{pod=~"(.*)yb-(.*)"}'
+            # kube-state-metrics
+            - 'kube_pod_container_resource_requests_cpu_cores{pod=~"(.*)yb-(.*)"}'
+
+        static_configs:
+          - targets:
+            - "prometheus-k8s.openshift-monitoring.svc:9091"
+
+        metric_relabel_configs:
+          # Save the name of the metric so we can group_by since we cannot by __name__ directly...
+          - source_labels: ["__name__"]
+            regex: "(.*)"
+            target_label: "saved_name"
+            replacement: "$1"
+          - source_labels: ["pod"]
+            regex: "(.*)"
+            target_label: "pod_name"
+            replacement: "$1"
+          - source_labels: ["container"]
+            regex: "(.*)"
+            target_label: "container_name"
+            replacement: "$1"
+
+      {{- else }}
+
       - job_name: 'kubernetes-nodes'
 
         scheme: https
@@ -201,58 +245,32 @@ data:
             regex: "(.*)"
             target_label: "saved_name"
             replacement: "$1"
-
-
-      - job_name: 'kubernetes-pods'
-
-        kubernetes_sd_configs:
-        - role: pod
-
-        relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-          action: keep
-          regex: true
-        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-          action: replace
-          target_label: __metrics_path__
-          regex: (.+)
-        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-          action: replace
-          regex: ([^:]+)(?::\d+)?;(\d+)
-          replacement: $1:$2
-          target_label: __address__
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - source_labels: [__meta_kubernetes_namespace]
-          action: replace
-          target_label: kubernetes_namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: kubernetes_pod_name
-        metric_relabel_configs:
-          # Save the name of the metric so we can group_by since we cannot by __name__ directly...
-          - source_labels: ["__name__"]
+          - source_labels: ["pod"]
             regex: "(.*)"
-            target_label: "saved_name"
+            target_label: "pod_name"
+            replacement: "$1"
+          - source_labels: ["container"]
+            regex: "(.*)"
+            target_label: "container_name"
             replacement: "$1"
 
       - job_name: 'kube-state-metrics'
         static_configs:
         - targets: ['kube-state-metrics.kube-system.svc.{{.Values.domainName}}:8080']
         metric_relabel_configs:
-        # Save the name of the metric so we can group_by since we cannot by __name__ directly...
-        - source_labels: ["__name__"]
-          regex: "(.*)"
-          target_label: "saved_name"
-          replacement: "$1"
-        - source_labels: [pod]
-          regex: "(.*)"
-          target_label: "pod_name"
-          replacement: "$1"
-        - source_labels: [pod]
-          regex: "(yb-[^-]*)-(.*)"
-          target_label: "container_name"
-          replacement: "$1"
+          # Save the name of the metric so we can group_by since we cannot by __name__ directly...
+          - source_labels: ["__name__"]
+            regex: "(.*)"
+            target_label: "saved_name"
+            replacement: "$1"
+          - source_labels: ["pod"]
+            regex: "(.*)"
+            target_label: "pod_name"
+            replacement: "$1"
+          - source_labels: ["container"]
+            regex: "(.*)"
+            target_label: "container_name"
+            replacement: "$1"
 
       - job_name: 'kubernetes-cadvisor'
 
@@ -280,6 +298,16 @@ data:
             regex: "(.*)"
             target_label: "saved_name"
             replacement: "$1"
+          - source_labels: ["pod"]
+            regex: "(.*)"
+            target_label: "pod_name"
+            replacement: "$1"
+          - source_labels: ["container"]
+            regex: "(.*)"
+            target_label: "container_name"
+            replacement: "$1"
+
+      {{- end }}
 
       - job_name: "node"
         file_sd_configs:

--- a/stable/yugaware/templates/rbac.yaml
+++ b/stable/yugaware/templates/rbac.yaml
@@ -7,6 +7,23 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 {{- if .Values.rbac.create }}
+{{- if .Values.ocpCompatibility.enabled }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-cluster-monitoring-view
+  labels:
+    app: yugaware
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-monitoring-view
+  apiGroup: rbac.authorization.k8s.io
+{{- else }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -62,4 +79,5 @@ roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -162,7 +162,7 @@ spec:
           {{- end }}
           command: [ "/bin/bash", "-c"]
           args:
-            - "cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml && ln -s /opt/yugabyte/yugaware/data /opt/yugaware_data && ln -s /opt/yugabyte/releases /opt/releases && bin/yugaware -Dconfig.file=/data/application.docker.conf"
+            - "cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml && bin/yugaware -Dconfig.file=/data/application.docker.conf"
           env:
             - name: POSTGRES_USER
               valueFrom:
@@ -193,8 +193,16 @@ spec:
           - name: yugaware-storage
             mountPath: /opt/yugabyte/yugaware/data/
             subPath: data
+          # old path for backward compatibility
+          - name: yugaware-storage
+            mountPath: /opt/yugaware_data/
+            subPath: data
           - name: yugaware-storage
             mountPath: /opt/yugabyte/releases/
+            subPath: releases
+          # old path for backward compatibility
+          - name: yugaware-storage
+            mountPath: /opt/releases/
             subPath: releases
           - name: yugaware-storage
             mountPath: /opt/yugabyte/prometheus/targets

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -74,9 +74,10 @@ helm2Legacy: false
 ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment
 
 rbac:
-  ## Does not create (Cluster) Role and Binding if false. When set to
-  ## false, some of the graphs from Container section of the Metrics
-  ## UI don't work.
+  ## Set this to false if you don't have enough permissions to create
+  ## ClusterRole and Binding, for example an OpenShift cluster. When
+  ## set to false, some of the graphs from Container section of the
+  ## Metrics UI don't work.
   create: true
 
 ## In order to deploy on OpenShift Container Platform, set this to


### PR DESCRIPTION
### [Platform] Use OpenShift's Prometheus for container related metrics

In OpenShift, there is already a Prometheus in the
openshift-monitoring namespace which collects data from:

- All the kubelet and their cadvisor endpoints.
- kube-state-metrics from same namespace.

To be able to scrape this Prometheus using its /federate endpoint we
need the cluster-monitoring-view ClusterRole. ref:
https://docs.openshift.com/container-platform/4.5/monitoring/cluster_monitoring/prometheus-alertmanager-and-grafana.html

- With this change we are fetching the only metrics which we need from
  the OCP's Prometheus.
- Remove the kubernetes-pods job as we don't use it, and it can make
  our Prometheus scrape unrelated pods from the cluster (the ones
  which have prometheus.io/scrape label). This can result in more disk
  utilization.
- Add pod_name and container_name labels. These have take of pod and
  container labels respectively. Kubernetes 1.16 has only pod and
  container
  labels. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#removed-metrics
- Not using the kubernetes.io/cluster-service and addonmanager.*
  labels for the ClusterRoleBinding as those are not required in our
  case. ref: https://git.io/Jqvjn

Scenarios tested:
- Created a new universe in OpenShift, it is showing the container
  related graphs correctly in the UI.

Fixes yugabyte/yugabyte-db#6611

### [Platform] Add old mountpoints for backward compatibility

4ceb0ce changed few default mount points, and added command to create
symlinks at old paths. This doesn't work in case of OpenShift, as we
don't have access to create new directories in /opt. This can happen
in any Kubernetes deployment which runs the pods as non root.

```
ln: failed to create symbolic link '/opt/yugaware_data': Permission denied
```

To solve this, mounting the same volume subPath at both old as well as
new locations. And removing the ln command.

Scenarios tested:
- Upgraded an existing platform Helm release with these changes,
  universe creation is working as expected.