### PR TITLE
[YW] Added initContainer to copy the prometheus configuration

### DIFF
--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -67,9 +67,7 @@ spec:
       initContainers:
         - image: {{ include "full_yugaware_image" . }}
           name: prometheus-configuration
-          command: [ "/bin/sh", "-c"]
-          args:
-            - "cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml"
+          command: ["cp", "/default_prometheus_config/prometheus.yml", "/prometheus_configs/prometheus.yml"]
           {{- if .Values.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -194,8 +192,6 @@ spec:
           - name: yugaware-storage
             mountPath: /opt/yugabyte/prometheus/rules
             subPath: swamper_rules
-          - name: prometheus-config
-            mountPath: /default_prometheus_config
           - name: yugaware-storage
             mountPath: /prometheus_configs
             subPath: prometheus.yml

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -64,6 +64,22 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-yugaware-tls-cert
         {{- end }}
+      initContainers:
+        - image: {{ include "full_yugaware_image" . }}
+          name: prometheus-configuration
+          command: [ "/bin/sh", "-c"]
+          args:
+            - "cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml"
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
+          volumeMounts:
+          - name: prometheus-config
+            mountPath: /default_prometheus_config
+          - name: yugaware-storage
+            mountPath: /prometheus_configs
+            subPath: prometheus.yml
       containers:
         - image: {{ include "full_image" (dict "containerName" "postgres" "root" .) }}
           name: postgres
@@ -130,7 +146,7 @@ spec:
           {{- end }}
           command: [ "/bin/bash", "-c"]
           args:
-            - "cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml && bin/yugaware -Dconfig.file=/data/application.docker.conf"
+            - "bin/yugaware -Dconfig.file=/data/application.docker.conf"
           env:
             - name: POSTGRES_USER
               valueFrom:


### PR DESCRIPTION
### Summary

- Added `initContainer` in the YW helm chart to copy the Prometheus configuration.

### Test Plan

- Deployed the YW & spin up the YB universe on GCP. Updated the Prometheus configuration & is reflected in the Prometheus.

fixes: https://github.com/yugabyte/yugabyte-db/issues/7515