### PR TITLE
[Platform] Add new configuration options for K8s discovery API

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -74,6 +74,8 @@ data:
       health.default_email = "{{ .Values.yugaware.health.email }}"
       health.ses_email_username = "{{ .Values.yugaware.health.username }}"
       health.ses_email_password = "{{ .Values.yugaware.health.password }}"
+      kubernetes.storageClass = "{{ .Values.yugaware.storageClass }}"
+      kubernetes.pullSecretName = "{{ .Values.image.pullSecret }}"
     }
 
     play.filters {


### PR DESCRIPTION
This adds the two new configuration options required by the Kubernetes
discovery API which is introduced in
https://github.com/yugabyte/yugabyte-db/pull/8371

Test plan:
- Upgraded existing Helm release, the API works as expected.

_Note: this can be merged once https://github.com/yugabyte/yugabyte-db/pull/8371 is merged._

Reference: https://github.com/yugabyte/yugabyte-db/issues/7394