### PR TITLE
[yugabyte] Changes for multicluster solutions

### DIFF
--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -109,7 +109,9 @@ Get YugaByte fs data directories.
 Generate server FQDN.
 */}}
 {{- define "yugabyte.server_fqdn" -}}
-  {{- if .Values.oldNamingStyle -}}
+  {{- if (and .Values.istioCompatibility.enabled .Values.multicluster.createServicePerPod) -}}
+    {{- printf "$(HOSTNAME).$(NAMESPACE).svc.%s" .Values.domainName -}}
+  {{- else if .Values.oldNamingStyle -}}
     {{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .Service.name .Values.domainName -}}
   {{- else -}}
     {{- printf "$(HOSTNAME).%s-%s.$(NAMESPACE).svc.%s" (include "yugabyte.fullname" .) .Service.name .Values.domainName -}}

--- a/stable/yugabyte/templates/multicluster-common-tserver-service.yaml
+++ b/stable/yugabyte/templates/multicluster-common-tserver-service.yaml
@@ -1,0 +1,23 @@
+{{- if (and .Values.multicluster.createCommonTserverService (not .Values.oldNamingStyle)) }}
+{{- range $service := .Values.serviceEndpoints }}
+{{- if eq $service.name "yb-tserver-service" }}
+{{- $appLabelArgs := dict "label" $service.app "root" $ -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "yb-tserver-common"
+  labels:
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- include "yugabyte.labels" $ | indent 4 }}
+spec:
+  ports:
+    {{- range $label, $port := $service.ports }}
+    - name: {{ $label | quote }}
+      port: {{ $port }}
+    {{- end }}
+  selector:
+    {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/yugabyte/templates/multicluster-multiple-services.yaml
+++ b/stable/yugabyte/templates/multicluster-multiple-services.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.multicluster.createServicePerPod }}
+{{- range $server := .Values.Services }}
+{{- range $replicaNum := until (int (ternary $.Values.replicas.master $.Values.replicas.tserver (eq $server.name "yb-masters"))) }}
+{{- $appLabelArgs := dict "label" $server.label "root" $ -}}
+{{- $podName := $.Values.oldNamingStyle | ternary $server.label (printf "%s-%s" (include "yugabyte.fullname" $) $server.label) -}}
+{{- $podName := printf "%s-%d" $podName $replicaNum -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $podName | quote }}
+  labels:
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- include "yugabyte.labels" $ | indent 4 }}
+spec:
+  ports:
+    {{- range $label, $port := $server.ports }}
+    - name: {{ $label | quote }}
+      port: {{ $port }}
+    {{- end}}
+  selector:
+    statefulset.kubernetes.io/pod-name: {{ $podName | quote }}
+    {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
+---
+{{- end }}
+{{- end }}
+{{- end }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -406,7 +406,7 @@ spec:
           - name: {{ $root.Values.oldNamingStyle | ternary "datadir0" (printf "%s0" (include "yugabyte.volume_name" $root)) }}
             mountPath: /home/yugabyte/
             subPath: yb-data
-          - name: datadir0
+          - name: {{ $root.Values.oldNamingStyle | ternary "datadir0" (printf "%s0" (include "yugabyte.volume_name" $root)) }}
             mountPath: /var/yugabyte/cores
             subPath: cores
       {{- end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -109,6 +109,16 @@ Services:
 istioCompatibility:
   enabled: false
 
+## Settings required when using multicluster environment.
+multicluster:
+  ## Creates a ClusterIP service for each yb-master and yb-tserver
+  ## pod.
+  createServicePerPod: false
+  ## creates a ClusterIP service whos name does not have release name
+  ## in it. A common service across different clusters for automatic
+  ## failover. Useful when using new naming style.
+  createCommonTserverService: false
+
 serviceMonitor:
   ## If true, two ServiceMonitor CRs are created. One for yb-master
   ## and one for yb-tserver


### PR DESCRIPTION
Some of the multicluster solutions need this setup where we have one service per pod, due to some bug or no support for Statefulset + headless services on which we rely. multicluster.createServicePerPod does that.

We have to use new naming style with a different release name across multiple clusters, so that the Master and TServer pods get a unique identity across clusters. In this case we still need a common name across these clusters, multiple.createCommonTserverService creates a service with a name independent of release name.

Scenarios tested:
- As this is behind a flag, this does not affect any existing deployments.
- These flags have been tested with Istio multicluster setup.