### PR TITLE
Keep PG password between release upgrades

### DIFF
--- a/stable/yugaware/templates/_helpers.tpl
+++ b/stable/yugaware/templates/_helpers.tpl
@@ -80,3 +80,19 @@ Validate Nginx SSL protocols
     {{- .Values.tls.sslProtocols -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Get or generate PG password
+Source - https://github.com/helm/charts/issues/5167#issuecomment-843962731
+*/}}
+{{- define "getOrGeneratePassword" }}
+{{- $len := (default 8 .Length) | int -}}
+{{- $obj := (lookup "v1" .Kind .Namespace .Name).data -}}
+{{- if $obj }}
+{{- index $obj .Key -}}
+{{- else if (eq (lower .Kind) "secret") -}}
+{{- randAlphaNum $len | b64enc -}}
+{{- else -}}
+{{- randAlphaNum $len -}}
+{{- end -}}
+{{- end }}

--- a/stable/yugaware/templates/global-config.yaml
+++ b/stable/yugaware/templates/global-config.yaml
@@ -12,6 +12,6 @@ metadata:
     heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 data:
   postgres_user: "postgres"
-  postgres_password: "{{ b64enc (randAlphaNum 8) }}"
+  postgres_password: "{{ include "getOrGeneratePassword" (dict "Namespace" .Release.Namespace "Kind" "ConfigMap" "Name" (printf "%s%s" .Release.Name "-yugaware-global-config") "Key" "postgres_password") }}"
   postgres_db: "yugaware"
   app_secret: "{{ b64enc (randAlphaNum 64) }}"


### PR DESCRIPTION
Change been checked this way:
```
$ helm upgrade --install --create-namespace -n sd-test yw .                                
Release "yw" does not exist. Installing it now.
NAME: yw
LAST DEPLOYED: Tue Jun  8 15:56:26 2021
NAMESPACE: sd-test
STATUS: deployed
REVISION: 1
TEST SUITE: None
$ kubectl -n sd-test get configmap/yw-yugaware-global-config -o 'jsonpath={.data.postgres_password}'
PR9sEIfC
$ helm upgrade --install --create-namespace -n sd-test yw .                                         
...
REVISION: 2
...
$ kubectl -n sd-test get configmap/yw-yugaware-global-config -o 'jsonpath={.data.postgres_password}'
PR9sEIfC
```
But `helm template` shows some random value, what should be ok.