### PR TITLE
[charts] Added new k8s label topology.kubernetes.io/zone

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -181,6 +181,11 @@ spec:
                 operator: In
                 values:
                 - {{ $root.Values.AZ }}
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - {{ $root.Values.AZ }}
         {{ end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
### Summary

- Earlier it was using this label `failure-domain.beta.kubernetes.io/zone` for the same purpose & it's deprecated.
- Now the YB charts have both labels in the node affinity, which means one should exist on the node to schedule a pod.
- `nodeSelectorTerms` is ORed, and `matchExpressions` is Anded expression.

### Test Plan:
Used this official YB doc to deploy the universe in a multi-zone scenario.
https://docs.yugabyte.com/latest/deploy/kubernetes/multi-zone/gke/helm-chart/

Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity

Fixes https://github.com/yugabyte/yugabyte-db/issues/8586