### PR TITLE
[BACKPORT 2.6][platform] Restart pod if the configuration changes

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -1,19 +1,4 @@
 # Copyright (c) YugaByte, Inc.
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-yugaware-global-config
-  labels:
-    app: {{ template "yugaware.name" . }}
-    chart: {{ template "yugaware.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
-data:
-  postgres_user: "postgres"
-  postgres_password: "{{ include "getOrGeneratePassword" (dict "Namespace" .Release.Namespace "Kind" "ConfigMap" "Name" (printf "%s%s" .Release.Name "-yugaware-global-config") "Key" "postgres_password") }}"
-  postgres_db: "yugaware"
-  app_secret: "{{ b64enc (randAlphaNum 64) }}"
 
 ---
 apiVersion: v1

--- a/stable/yugaware/templates/global-config.yaml
+++ b/stable/yugaware/templates/global-config.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) YugaByte, Inc.
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-yugaware-global-config
+  labels:
+    app: {{ template "yugaware.name" . }}
+    chart: {{ template "yugaware.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
+data:
+  postgres_user: "postgres"
+  postgres_password: "{{ include "getOrGeneratePassword" (dict "Namespace" .Release.Namespace "Kind" "ConfigMap" "Name" (printf "%s%s" .Release.Name "-yugaware-global-config") "Key" "postgres_password") }}"
+  postgres_db: "yugaware"
+  app_secret: "{{ b64enc (randAlphaNum 64) }}"

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -20,6 +20,8 @@ spec:
     metadata:
       labels:
         app: {{ .Release.Name }}-yugaware
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configs.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Release.Name }}
       imagePullSecrets:


### PR DESCRIPTION
- This adds checksum of the configs.yaml file to pod metadata as
  annotation. This causes it to change if there are any changes in the
  configuration, and results in a restart of the pod.
  https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
- Moving the global-config outside from configs.yaml, as it has a
  random string in it, which causes a restart everytime as the
  checksum keeps changing.

Test plan:
- Deployed platform chart in a Kubernetes cluster without this change.
- Upgraded the Helm release with this change (the pod restarts as
  expected).
- Add --set helm.timeout=1000 during the helm upgrade (the pod
  restarts as expected)
- Did another upgrade with same command as above (the pod does not
  restart as the configuration is the same).