### PR TITLE
[Yugabyte charts] Added nested flag for EKS kubernetai multi-cluster

### DIFF
--- a/stable/yugabyte/templates/multicluster-common-tserver-service.yaml
+++ b/stable/yugabyte/templates/multicluster-common-tserver-service.yaml
@@ -1,4 +1,4 @@
-{{- if (and .Values.multicluster.createCommonTserverService (not .Values.oldNamingStyle)) }}
+{{- if (and .Values.multicluster.createCommonTserverService.enabled (not .Values.oldNamingStyle)) }}
 {{- range $service := .Values.serviceEndpoints }}
 {{- if eq $service.name "yb-tserver-service" }}
 {{- $appLabelArgs := dict "label" $service.app "root" $ -}}
@@ -10,6 +10,9 @@ metadata:
     {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
     {{- include "yugabyte.labels" $ | indent 4 }}
 spec:
+  {{- if $.Values.multicluster.createCommonTserverService.headless }}
+  clusterIP: None
+  {{- end }}
   ports:
     {{- range $label, $port := $service.ports }}
     - name: {{ $label | quote }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -117,7 +117,11 @@ multicluster:
   ## creates a ClusterIP service whos name does not have release name
   ## in it. A common service across different clusters for automatic
   ## failover. Useful when using new naming style.
-  createCommonTserverService: false
+  createCommonTserverService:
+    enabled: false
+    ## To make above common Tserver service as headless service
+    ## Can be useful in Kubernetai
+    headless: false
 
 serviceMonitor:
   ## If true, two ServiceMonitor CRs are created. One for yb-master


### PR DESCRIPTION
### Summary

Added a nested flag in common Tserver service values to make the service headless because Kubernetai requires the headless service in the remote cluster to access the pods.

### Test plan
After deploying the common headless Tserver service, the client can connect with remote cluster Tserver pods in case of Tserver pod failure in the current cluster.