### PR TITLE
[PLAT-1576] Add CORS allowed origins list to parameters

### DIFF
--- a/stable/yugaware/templates/_helpers.tpl
+++ b/stable/yugaware/templates/_helpers.tpl
@@ -95,4 +95,20 @@ Source - https://github.com/helm/charts/issues/5167#issuecomment-843962731
 {{- else -}}
 {{- randAlphaNum $len -}}
 {{- end -}}
-{{- end }}
+{{- end -}}
+
+{{/*
+Make list of allowed CORS origins
+*/}}
+{{- define "allowedCorsOrigins" -}}
+[
+{{- if .Values.tls.enabled -}}
+"https://{{ .Values.tls.hostname }}",
+{{- else -}}
+"http://{{ .Values.tls.hostname }}",
+{{- end -}}
+{{- range .Values.yugaware.additionAllowedCorsOrigins -}}
+{{- . | quote }},
+{{- end -}}
+]
+{{- end -}}

--- a/stable/yugaware/templates/_helpers.tpl
+++ b/stable/yugaware/templates/_helpers.tpl
@@ -102,13 +102,13 @@ Make list of allowed CORS origins
 */}}
 {{- define "allowedCorsOrigins" -}}
 [
-{{- if .Values.tls.enabled -}}
-"https://{{ .Values.tls.hostname }}",
-{{- else -}}
-"http://{{ .Values.tls.hostname }}",
-{{- end -}}
 {{- range .Values.yugaware.additionAllowedCorsOrigins -}}
 {{- . | quote }},
+{{- end -}}
+{{- if .Values.tls.enabled -}}
+"https://{{ .Values.tls.hostname }}"
+{{- else -}}
+"http://{{ .Values.tls.hostname }}"
 {{- end -}}
 ]
 {{- end -}}

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -101,11 +101,7 @@ data:
       # CORS config
       cors {
         pathPrefixes = ["/"]
-{{- if .Values.tls.enabled }}
-        allowedOrigins = ["https://{{ .Values.tls.hostname }}"]
-{{- else }}
-        allowedOrigins = ["http://{{ .Values.tls.hostname }}"]
-{{- end }}
+        allowedOrigins = {{ include "allowedCorsOrigins" . }}
         # Server allows cookies/credentials to be sent with cross-origin requests
         supportsCredentials=true
         allowedHttpMethods = ["GET", "POST", "PUT", "OPTIONS", "DELETE"]

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -64,8 +64,6 @@ yugaware:
   enableProxyMetricsAuth: true
   ## List of additional alowed CORS origins in case of complex rev-proxy
   additionAllowedCorsOrigins: []
-  #   - http://external.host.domain.local
-  #   - https://mylocalhost
   proxyEndpointTimeoutMs: 1 minute
   ## Enables features specific for cloud deployments
   cloud:

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -57,7 +57,11 @@ yugaware:
       cpu: 2
       memory: 4Gi
   enableProxyMetricsAuth: true
-  # enables features specific for cloud deployments
+  ## List of additional alowed CORS origins in case of complex rev-proxy
+  additionAllowedCorsOrigins: []
+  #   - http://external.host.domain.local
+  #   - https://mylocalhost
+  ## Enables features specific for cloud deployments
   cloud:
     enabled: false
 


### PR DESCRIPTION
Without anything set - `helm template sd-test .`
```
....
                allowedOrigins = ["http://localhost"]
....
```

With the following overrides:
```
yugaware:
  additionAllowedCorsOrigins:
    - http://asd
    - dsa
```
and template `helm template sd-test . -f o.yaml` it comes to
```
....
allowedOrigins = ["http://asd","dsa","http://localhost"]
....
```

Format itself checked manually on cloud platform.