### PR TITLE
Added option to set custom annotations to the StatefulSet

### DIFF
--- a/stable/yugabyte/questions.yaml
+++ b/stable/yugabyte/questions.yaml
@@ -66,3 +66,9 @@
     type: boolean
     required: true
     label: Cert-Manager Support
+    - variable: statefulSetAnnotations
+    default: {}
+    description: Annotations for the StatefulSet
+    type: dict
+    required: false
+    label: "Annotations for the StatefulSet"

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -112,6 +112,10 @@ metadata:
   labels:
     {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
     {{- include "yugabyte.labels" $root | indent 4 }}
+  {{ if $root.Values.statefulSetAnnotations }}
+  annotations:
+{{ toYaml $root.Values.statefulSetAnnotations | indent 4}}
+  {{ end }}
 spec:
   serviceName: {{ $root.Values.oldNamingStyle | ternary .name (printf "%s-%s" (include "yugabyte.fullname" $root) .name) | quote }}
   podManagementPolicy: {{ $root.Values.PodManagementPolicy }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -112,10 +112,10 @@ metadata:
   labels:
     {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
     {{- include "yugabyte.labels" $root | indent 4 }}
-  {{ if $root.Values.statefulSetAnnotations }}
+  {{- if $root.Values.statefulSetAnnotations }}
   annotations:
-{{ toYaml $root.Values.statefulSetAnnotations | indent 4}}
-  {{ end }}
+{{ toYaml $root.Values.statefulSetAnnotations | indent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ $root.Values.oldNamingStyle | ternary .name (printf "%s-%s" (include "yugabyte.fullname" $root) .name) | quote }}
   podManagementPolicy: {{ $root.Values.PodManagementPolicy }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -213,6 +213,8 @@ tolerations: []
 
 affinity: {}
 
+statefulSetAnnotations: {}
+
 helm2Legacy: false
 
 ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment


### PR DESCRIPTION
Added the option to set custom annotations to the StatefulSet.
Intended first use on our cluster would be to add an annotation for wave ( https://github.com/wave-k8s/wave ) to be able to trigger a rolling-update of the pods, when the SSL certificates of the cluster are renewed. I'm sure, there are lots of further use cases.