### PR TITLE
Make PodDisruptionBudget configurable.

### DIFF
--- a/stable/yugaware/templates/pdb.yaml
+++ b/stable/yugaware/templates/pdb.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-yugaware-pdb
 spec:
-  maxUnavailable: 0
+  maxUnavailable: {{ .Values.yugaware.podDisruptionBudget.maxUnavailable | toJson }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-yugaware

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -69,6 +69,11 @@ yugaware:
   cloud:
     enabled: false
 
+  podDisruptionBudget:
+    # See https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+    # Note that the default of 0 doesn't really make sense since a StatefulSet isn't allowed to schedule extra replicas. However it is maintained as the default while we do additional testing. This value will likely change in the future.
+    maxUnavailable: 0
+
 ## Configure PostgreSQL part of the application
 postgres:
   service:


### PR DESCRIPTION
The old default of `maxUnavailable: 0` doesn't make sense because a StatefulSet doesn't allow extra replicas to be scheduled (not that kube tries to upsize collections anyways). This effectively means that the pods will never be allowed to be evicted which just results in inefficient use of a kube cluster and block updates. This makes the PDB configurable to allow testing of a better configuration.

Likely this will be updated to a different default value once it has been tested.