### PR TITLE
[2.8][yugabyte] Add liveness and preflight check based on disk IO

### DIFF
--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -106,6 +106,16 @@ Get YugaByte fs data directories.
 {{- end -}}
 
 {{/*
+Get files from fs data directories for readiness / liveness probes.
+*/}}
+{{- define "yugabyte.fs_data_dirs_probe_files" -}}
+  {{- range $index := until (int (.count)) -}}
+    {{- if ne $index 0 }} {{ end }}"/mnt/disk{{ $index -}}/disk.check"
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
 Generate server FQDN.
 */}}
 {{- define "yugabyte.server_fqdn" -}}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -229,6 +229,18 @@ spec:
                       cp /home/yugabyte/bin/log_cleanup.sh /mnt/disk0/yb-data/scripts;
                     fi;
                   fi
+        {{- if (and (not $root.Values.storage.ephemeral) (not $service.skipHealthChecks)) }}
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - touch {{ template "yugabyte.fs_data_dirs_probe_files" $storageInfo }}
+          failureThreshold: 3
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        {{- end }}
         env:
         - name: POD_IP
           valueFrom:
@@ -261,6 +273,9 @@ spec:
           - "/bin/bash"
           - "-c"
           - |
+          {{- if (and (not $root.Values.storage.ephemeral) (not $root.Values.preflight.skipAll)) }}
+            touch {{ template "yugabyte.fs_data_dirs_probe_files" $storageInfo }} && \
+          {{- end }}
           {{- $rpcAddr := include "yugabyte.rpc_bind_address" $serviceValues -}}
           {{- $rpcPort := index $service.ports "tcp-rpc-port" -}}
           {{- $rpcDict := dict "Addr" $rpcAddr "Port" $rpcPort -}}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -104,6 +104,7 @@ serviceEndpoints:
 Services:
   - name: "yb-masters"
     label: "yb-master"
+    skipHealthChecks: false
     memory_limit_to_ram_ratio: 0.85
     ports:
       http-ui: "7000"
@@ -111,6 +112,7 @@ Services:
 
   - name: "yb-tservers"
     label: "yb-tserver"
+    skipHealthChecks: false
     ports:
       http-ui: "9000"
       tcp-rpc-port: "9100"
@@ -233,7 +235,8 @@ authCredentials:
 oldNamingStyle: true
 
 preflight:
-  # Set to true to skip DNS address resolution and port bind checks
+  # Set to true to skip disk IO check, DNS address resolution, and
+  # port bind checks
   skipAll: false
   # Set to true to skip port bind checks
   skipBind: false


### PR DESCRIPTION
Original commit: 9248b65

- In some Kubernetes setups it is possible that underlying disk dies
  and writes from TServer fail but this failure is not detected
  immediately, instead it is detected only during next write operation
  by TServer.
- This adds a simple liveness check to the database pods to check if
  the disk is readable and writable.
- If the check fails, kubelet restarts the pod.
- Adds a similar preflight check which will prevent the database
  process from starting if disk IO fails.

Scenarios tested:
- Ran helm install --dry-run to check the generated YAML
- Installed the chart with 2.8.0.0-b19 image.
