### PR TITLE
Update apiVersion of non chart RBAC manifests

### DIFF
--- a/rbac/platform-global-admin.yaml
+++ b/rbac/platform-global-admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: yugabyte-platform-global-admin

--- a/rbac/platform-namespaced-admin.yaml
+++ b/rbac/platform-namespaced-admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: yugabyte-platform-global-admin

--- a/stable/yugabyte/yugabyte-rbac.yaml
+++ b/stable/yugabyte/yugabyte-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: yugabyte-helm
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: yugabyte-helm


### PR DESCRIPTION
rbac.authorization.k8s.io/v1 has been available since Kubernetes 1.8
and the v1beta1 has been removed in 1.22.

Scenarios tested:
- Applied the v1beta1 version of the resource to the cluster.
- Applied the v1 version of the resource to the cluster.
- It worked as expected.