### PR TITLE
[Platform] Service Account related changes for YB platform GKE app

### DIFF
--- a/stable/yugaware/templates/rbac.yaml
+++ b/stable/yugaware/templates/rbac.yaml
@@ -1,7 +1,8 @@
+{{ if not .Values.yugaware.serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
   labels:
     k8s-app: yugaware
     kubernetes.io/cluster-service: "true"
@@ -10,6 +11,7 @@ metadata:
   annotations:
 {{ toYaml .Values.yugaware.serviceAccountAnnotations | indent 4 }}
 {{- end }}
+{{ end }}
 {{- if .Values.rbac.create }}
 {{- if .Values.ocpCompatibility.enabled }}
 ---
@@ -21,7 +23,7 @@ metadata:
     app: yugaware
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
@@ -77,7 +79,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}
+  name: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/stable/yugaware/templates/rbac.yaml
+++ b/stable/yugaware/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
+  name: {{ .Release.Name }}
   labels:
     k8s-app: yugaware
     kubernetes.io/cluster-service: "true"

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-yugaware
     spec:
-      serviceAccountName: {{ .Release.Name }}
+      serviceAccountName: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
       imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}
       {{- if .Values.securityContext.enabled }}

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -41,7 +41,10 @@ yugaware:
   storageClass: ""
   storageAnnotations: {}
   multiTenant: false
-  serviceAccount: yugaware
+  # Providing service account externally won't create new SA.
+  # It just attaches the clusterrole to it. 
+  # Helpful in Yugabyte Platform GKE App. 
+  serviceAccount: ''
   serviceMonitor:
     enabled: false
     annotations: {}

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -41,9 +41,9 @@ yugaware:
   storageClass: ""
   storageAnnotations: {}
   multiTenant: false
-  # Providing service account externally won't create new SA.
-  # It just attaches the clusterrole to it. 
-  # Helpful in Yugabyte Platform GKE App. 
+  ## Name of existing ServiceAccount. When provided, the chart won't create a ServiceAccount.
+  ## It will attach the required RBAC roles to it. 
+  ## Helpful in Yugabyte Platform GKE App. 
   serviceAccount: ''
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
### Summary
YB platform charts are using the `{{ .Release.Name }}` instead of `yugaware.serviceAccount` of `values.yaml` for SA mentioned in STS.
The YB Platform GKE app creates the service account and attaches the RBAC permissions provided in `schema.yaml`.
As per the YB Platform GKE app requirements, we have modified the charts by which we can skip the SA creation by providing the SA name externally.
These changes won't impact the existing installation because the charts never used the `yugaware.serviceAccount`.

- Service account can be pass-through using the `--set`. It'll help in the YB Platform GKE app. 

### Test

- Compared the output of `helm template` with and without service account.
```bash
helm template yw-test stable/yugaware/ --set yugaware.serviceAccount=test-sa
helm template yw-test stable/yugaware/ 
```