### PR TITLE
[yugabyte] Added static IP for load balancer service

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -100,6 +100,7 @@ spec:
     {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
   type: {{ $endpoint.type }}
   externalTrafficPolicy: {{ $endpoint.externalTrafficPolicy | default "Cluster" }}
+  loadBalancerIP: {{ $endpoint.loadBalancerIP }}
 {{- end}}
 {{- end}}
 {{ end }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -100,7 +100,9 @@ spec:
     {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
   type: {{ $endpoint.type }}
   externalTrafficPolicy: {{ $endpoint.externalTrafficPolicy | default "Cluster" }}
+  {{- if $endpoint.loadBalancerIP }}
   loadBalancerIP: {{ $endpoint.loadBalancerIP }}
+  {{- end }}
 {{- end}}
 {{- end}}
 {{ end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -92,6 +92,7 @@ serviceEndpoints:
     ## Sets the Service's externalTrafficPolicy
     # externalTrafficPolicy: ""
     app: "yb-master"
+    loadBalancerIP: ""
     ports:
       http-ui: "7000"
 
@@ -100,6 +101,7 @@ serviceEndpoints:
     ## Sets the Service's externalTrafficPolicy
     # externalTrafficPolicy: ""
     app: "yb-tserver"
+    loadBalancerIP: ""
     ports:
       tcp-yql-port: "9042"
       tcp-yedis-port: "6379"

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -92,7 +92,7 @@ serviceEndpoints:
     ## Sets the Service's externalTrafficPolicy
     # externalTrafficPolicy: ""
     app: "yb-master"
-    loadBalancerIP: ""
+    # loadBalancerIP: ""
     ports:
       http-ui: "7000"
 
@@ -101,7 +101,7 @@ serviceEndpoints:
     ## Sets the Service's externalTrafficPolicy
     # externalTrafficPolicy: ""
     app: "yb-tserver"
-    loadBalancerIP: ""
+    # loadBalancerIP: ""
     ports:
       tcp-yql-port: "9042"
       tcp-yedis-port: "6379"


### PR DESCRIPTION
### Summary

- Added static IP support for load balancer service.
- Using this, we can associate YB Master UI and YB Tserver with reserved static IP.

### Testing

- I have passed the `values.yaml`, which has static IP, to `helm install` command with version - `2.9.1.0-b140`.
```bash
helm install yb-test stable/yugabyte/ -n test -f stable/yugabyte/values.yaml 
```

fix: https://github.com/yugabyte/yugabyte-db/issues/10804
