### PR TITLE
[BACKPORT 2.6] Use policy/v1 of PodDisruptionBudget when available

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -446,7 +446,15 @@ spec:
         {{- end }}
 {{- if eq $root.Values.isMultiAz false }}
 ---
+{{/*
+TODO: switch to policy/v1 completely when we stop supporting
+Kubernetes versions < 1.21
+*/}}
+{{- if $root.Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ $root.Values.oldNamingStyle | ternary (printf "%s-pdb" .label) (printf "%s-%s-pdb" (include "yugabyte.fullname" $root) .name) }}

--- a/stable/yugaware/templates/pdb.yaml
+++ b/stable/yugaware/templates/pdb.yaml
@@ -1,4 +1,14 @@
+{{/*
+TODO: switch to policy/v1 completely when we stop supporting
+Kubernetes versions < 1.21
+*/}}
+{{- if .Values.pdbPolicyVersionOverride }}
+apiVersion: policy/{{ .Values.pdbPolicyVersionOverride }}
+{{- else if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-yugaware-pdb

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -120,3 +120,10 @@ prometheus:
       cpu: 2
       memory: 4Gi
   retentionTime: 15d
+
+## Override the APIVersion used by policy group for
+## PodDisruptionBudget resources. The chart selects the correct
+## APIVersion based on the target Kubernetes cluster. You don't need
+## to modify this unless you are using helm template command i.e. GKE
+## app's deployer image against a Kubernetes cluster >= 1.21.
+# pdbPolicyVersionOverride: "v1beta1"


### PR DESCRIPTION
Original commit: 6031111c0ec73cfc1512986f952992775f27eabe

The policy/v1beta1 of PodDisruptionBudget has been deprecated and will
be removed in Kubernetes version 1.25. With this change we use
policy/v1 of PodDisruptionBudget if it is available in the cluster or
else we fallback to policy/v1beta1 for both the charts yugabyte and
yugaware.

In case of `helm template` command, it will always report that the
policy/v1/PodDisruptionBudget is missing unless we provide the
`--api-versions policy/v1/PodDisruptionBudget` argument to it. The
only place where `helm template` is used, is the GKE marketplace's
deployer image, where don't have control over the exact `helm
template` command. In that case the pdbPolicyVersionOverride value of
yugaware chart can be used to explicitly set the APIVersion.

Scenarios tested:
1. Tried the following template commands, which yield expected
   results.
   ```
   helm template ./yugabyte => uses v1beta1
   helm template ./yugaware => uses v1beta1
   helm template ./yugabyte --api-versions policy/v1/PodDisruptionBudget => uses v1
   helm template ./yugaware --api-versions policy/v1/PodDisruptionBudget => uses v1
   helm template ./yugaware --set pdbPolicyVersionOverride=v1 => uses v1
   ```

Fixes https://github.com/yugabyte/yugabyte-db/issues/10597