### PR TITLE
[BACKPORT 2.8][yugabyte] Make pod annotations, env, affinity configur…

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -99,6 +99,7 @@ spec:
   selector:
     {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
   type: {{ $endpoint.type }}
+  externalTrafficPolicy: {{ $endpoint.externalTrafficPolicy | default "Cluster" }}
 {{- end}}
 {{- end}}
 {{ end }}
@@ -156,10 +157,19 @@ spec:
       {{- include "yugabyte.appselector" ($appLabelArgs) | indent 6 }}
   template:
     metadata:
-      {{ if $root.Values.networkAnnotation }}
+      {{- if eq .name "yb-masters" }}
+      {{- if (or $root.Values.networkAnnotation $root.Values.master.podAnnotations) }}
       annotations:
-{{ toYaml $root.Values.networkAnnotation | indent 8}}
-      {{ end }}
+      {{- with $root.Values.networkAnnotation }}{{ toYaml . | nindent 8 }}{{ end }}
+      {{- with $root.Values.master.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
+      {{- end }}
+      {{- else }}
+      {{- if (or $root.Values.networkAnnotation $root.Values.tserver.podAnnotations) }}
+      annotations:
+      {{- with $root.Values.networkAnnotation }}{{ toYaml . | nindent 8 }}{{ end }}
+      {{- with $root.Values.tserver.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
+      {{- end }}
+      {{- end }}
       labels:
         {{- include "yugabyte.applabel" ($appLabelArgs) | indent 8 }}
         {{- include "yugabyte.labels" $root | indent 8 }}
@@ -211,6 +221,11 @@ spec:
                   - {{ $root.Release.Name | quote }}
                 {{- end }}
               topologyKey: kubernetes.io/hostname
+        {{- if eq .name "yb-masters" }}
+        {{- with $root.Values.master.affinity }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- else }}
+        {{- with $root.Values.tserver.affinity }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- end }}
       containers:
       - name: "{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
@@ -254,6 +269,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if eq .name "yb-masters" }}
+        {{- with $root.Values.master.extraEnv }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- else }}
+        {{- with $root.Values.tserver.extraEnv }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- end }}
         {{- if and $root.Values.tls.enabled $root.Values.tls.clientToServer (ne .name "yb-masters") }}
         - name: SSL_CERTFILE
           value: /root/.yugabytedb/root.crt
@@ -377,9 +397,12 @@ spec:
               --allow_insecure_connections={{ $root.Values.tls.insecure }} \
               --use_client_to_server_encryption={{ $root.Values.tls.clientToServer }} \
               --certs_for_client_dir=/opt/certs/yugabyte \
+              {{- if $root.Values.tserver.serverBroadcastAddress }}
+              --cert_node_filename={{ include "yugabyte.server_fqdn" $serviceValues }} \
+              {{- end }}
             {{- end }}
               --rpc_bind_addresses={{ $rpcAddr }} \
-              --server_broadcast_addresses={{ $broadcastAddr }} \
+              --server_broadcast_addresses={{ $root.Values.tserver.serverBroadcastAddress | default $broadcastAddr }} \
               --webserver_interface={{ $webserverAddr }} \
             {{- if not $root.Values.disableYsql }}
               --enable_ysql=true \

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -89,12 +89,16 @@ domainName: "cluster.local"
 serviceEndpoints:
   - name: "yb-master-ui"
     type: LoadBalancer
+    ## Sets the Service's externalTrafficPolicy
+    # externalTrafficPolicy: ""
     app: "yb-master"
     ports:
       http-ui: "7000"
 
   - name: "yb-tserver-service"
     type: LoadBalancer
+    ## Sets the Service's externalTrafficPolicy
+    # externalTrafficPolicy: ""
     app: "yb-tserver"
     ports:
       tcp-yql-port: "9042"
@@ -216,6 +220,69 @@ tolerations: []
 affinity: {}
 
 statefulSetAnnotations: {}
+
+master:
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#affinity-v1-core
+  ## This might override the default affinity from service.yaml
+  ## Example.
+  # affinity:
+  #   podAntiAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #         - key: app
+  #           operator: In
+  #           values:
+  #           - "yb-master"
+  #       topologyKey: kubernetes.io/hostname
+  affinity: {}
+
+  ## Extra environment variables passed to the Master pods.
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core
+  ## Example:
+  # extraEnv:
+  # - name: NODE_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.hostIP
+  extraEnv: []
+
+  ## Annotations to be added to the Master pods.
+  podAnnotations: {}
+
+tserver:
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#affinity-v1-core
+  ## This might override the default affinity from service.yaml
+  ## Example.
+  # affinity:
+  #   podAntiAffinity:
+  #     requiredDuringSchedulingIgnoredDuringExecution:
+  #     - labelSelector:
+  #         matchExpressions:
+  #         - key: app
+  #           operator: In
+  #           values:
+  #           - "yb-tserver"
+  #       topologyKey: kubernetes.io/hostname
+  affinity: {}
+
+  ## Extra environment variables passed to the TServer pods.
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core
+  ## Example:
+  # extraEnv:
+  # - name: NODE_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.hostIP
+  extraEnv: []
+
+  ## Annotations to be added to the TServer pods.
+  podAnnotations: {}
+
+  ## Sets the --server_broadcast_addresses flag on the TServer, no
+  ## preflight checks are done for this address. You might need to add
+  ## `use_private_ip: cloud` to the gflags.master and gflags.tserver.
+  serverBroadcastAddress: ""
 
 helm2Legacy: false
 


### PR DESCRIPTION
…able

Original commit: 96420269999a292285a416eaa3be1660a8aa1ec1

This also makes it possible to change externalTrafficPolicy for the
ServiceEndpoints, fallbacks to `Cluster` (Kubernetes default). Adds
ability to override the server_broadcast_address for TServer pods.

Adding two new sections (maps) to values.yaml as master and
tserver. Because maps are easy to override than lists (i.e. the
Services list we have). In the case of lists, one has to write the
whole list in their values file to override one key out of it. Maps
are merged recursively and hence it is possible to override a single
key.

1. The `master.affinity` and `tserver.affinity` can be used to
   override existing podAntiAffinity configuration as well as to add
   other affinity configuration like nodeAffinity, podAffinity.

2. `master.extraEnv` and `tserver.extraEnv` add given environment list
   to the respective pods.

3. `master.podAnnotations` and `tserver`podAnnotations` add given
   annotations to the pods. Useful in the setups where other tools depend
   on annotations to discover pods, for example, Prometheus can use these
   to monitor the pods.

4. `tserver.serverBroadcastAddress` can be used to override the default
   value of the `--server_broadcast_addresses` flag of TServer. Preflight
   checks are not done on the given `serverBroadcastAddress` as the value
   is mostly likely calculated when the pod runs.

   When tls.enabled is set along with this value, the
   `--cert_node_filename` flag with correct node name is added. This
   ensures that the yb-tserver process is able to find the correct
   certificate files generated by the chart.

Scenarios tested:

1. Ran helm template with the above change and without the change,
   only service's externalTrafficPolicy changes. Applying this doesn't
   cause any pod restart (tried with helm upgrade).
2. Ran helm template with the values of podAnnotations, affinity,
   extraEnv, serverBroadcastAddress set. The pods have all the values
   correctly set after the upgrade.

Ref: https://github.com/yugabyte/yugabyte-db/issues/10603