### PR TITLE
[BACKPORT 2.8.1][yugabyte] Added static IP for load balancer service (#102)

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -99,6 +99,9 @@ spec:
   selector:
     {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
   type: {{ $endpoint.type }}
+  {{- if $endpoint.loadBalancerIP }}
+  loadBalancerIP: {{ $endpoint.loadBalancerIP }}
+  {{- end }}
 {{- end}}
 {{- end}}
 {{ end }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -90,12 +90,14 @@ serviceEndpoints:
   - name: "yb-master-ui"
     type: LoadBalancer
     app: "yb-master"
+    # loadBalancerIP: ""
     ports:
       http-ui: "7000"
 
   - name: "yb-tserver-service"
     type: LoadBalancer
     app: "yb-tserver"
+    # loadBalancerIP: ""
     ports:
       tcp-yql-port: "9042"
       tcp-yedis-port: "6379"


### PR DESCRIPTION
### Summary
- Added static IP support for load balancer service.
- Using this, we can associate YB Master UI and YB Tserver with reserved static IP.

Testing

- I have passed the `values.yaml`, which has static IP, to `helm install` command with version - `2.9.1.0-b140`.
```bash
helm install yb-test stable/yugabyte/ -n test -f stable/yugabyte/values.yaml
```

fix: https://github.com/yugabyte/yugabyte-db/issues/10804
(cherry picked from commit d6a3a8b)