### PR TITLE
added value overrides for master broadcastaddress

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -350,7 +350,7 @@ spec:
               --allow_insecure_connections={{ $root.Values.tls.insecure }} \
             {{- end }}
               --rpc_bind_addresses={{ $rpcAddr }} \
-              --server_broadcast_addresses={{ $broadcastAddr }} \
+              --server_broadcast_addresses={{ $root.Values.master.serverBroadcastAddress | default $broadcastAddr }} \
               --webserver_interface={{ $webserverAddr }}
           {{- else }}
             {{- $cqlAddr := include "yugabyte.cql_proxy_bind_address" $serviceValues -}}
@@ -386,7 +386,7 @@ spec:
               --undefok=num_cpus,enable_ysql \
               --use_node_hostname_for_local_tserver=true \
             {{- if $root.Values.authCredentials.ysql.password }}
-              --ysql_enable_auth=true \
+              --ysql_enable_auth=true 
             {{- end }}
             {{- if or $root.Values.authCredentials.ycql.user $root.Values.authCredentials.ycql.password }}
               --use_cassandra_authentication=true \


### PR DESCRIPTION
FOR GKE MCS support. 
GKE MCS will need the override of server_broadcast_addresses. 