### PR TITLE
[Backport 2.6][yugabyte] Create a symlink to cores directory based on core_pattern

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -227,10 +227,20 @@ spec:
           postStart:
             exec:
               command:
-                - "sh"
+                - "bash"
                 - "-c"
-                - >
+                - |
                   mkdir -p /mnt/disk0/cores;
+                  # Create a symlink to cores directory based on core_pattern
+                  pattern="$(sysctl kernel.core_pattern --values || true)";
+                  core_dir="${pattern%/*}";
+                  if [ "${core_dir:0:1}" = "/" ]; then
+                    if [ ! -d "${core_dir}" ]; then
+                      # create the parent directory
+                      mkdir -p "${core_dir%/*}" || true;
+                      ln -s "/mnt/disk0/cores" "${core_dir}" || true;
+                    fi;
+                  fi;
                   mkdir -p /mnt/disk0/yb-data/scripts;
                   if [ ! -f /mnt/disk0/yb-data/scripts/log_cleanup.sh ]; then
                     if [ -f /home/yugabyte/bin/log_cleanup.sh ]; then


### PR DESCRIPTION
Original commit: 64c4c8f9b3a28a33d3bf7d1b4672e311b081baad

Modifies the postStart hook to create a symlink to /mnt/disk0/cores at
the directory being used by kernel.core_pattern. This is useful when
the core_pattern's value points to some absolute path like
/var/lib/cores instead of a relative path and the path doesn't exist
inside the container.

Changing to bash as some of the bash constructs are being used. The
current container image's sh is just a symlink to bash.

If core_pattern is set to pipe to some binary like
`|/bin/systemd-coredump …`, we don't do anything.

Scenarios tested:

- Installed the chart and verified if pods are in running state, (most
  of the testing has been done on the original commit).

Ref: https://github.com/yugabyte/yugabyte-db/issues/4385#issuecomment-717656848