### PR TITLE
[Backport 2.8][yugabyte][PLAT-2933] Use tini as entrypoint for YugabyteDB

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -293,6 +293,9 @@ spec:
         # https://github.com/yugabyte/charts/issues/11
         workingDir: "/mnt/disk0/cores"
         command:
+          - "/sbin/tini"
+          - "--"
+        args:
           - "/bin/bash"
           - "-c"
           - |


### PR DESCRIPTION
Original commit: 203b724976185d5f8b4a4dc6e715b47daf534e69

With this change, tini takes care of receiving all the signals as PID
1, and passing those to the running process like yb-master or
yb-tserver. It exits if the child process fails/exits.

The `bash -c "<some Python scripts> && exec yb-master …` in args
section of the Pod:
- Starts bash.
- That in-turn runs all the Python scripts required.
- And the bash gets replaced by the yb-master or yb-tserver process.
- This yb-master or yb-tserver becomes the direct child of tini, and
  receives the signals correctly.

If any of the scripts which run before the server process fail, the
container also crashes (expected behavior).

Scenarios tested:
- Deployed a cluster using these changes.
- Created tables, and inserted some data in both YSQL and YCQL.
- The ps command shows tini as PID 1 and yb-master as PID 8.
  ```
  $ ps -ax
      PID TTY      STAT   TIME COMMAND
	1 ?        Ss     0:00 /sbin/tini -- /bin/bash -c touch "/mnt/disk0/disk.check" "/mnt/disk1/disk.che
	8 ?        Sl     0:11 /home/yugabyte/bin/yb-master --fs_data_dirs=/mnt/disk0,/mnt/disk1 --master_ad
  ```
- Doing `kill -QUIT 8` makes the yb-master dump core and restarts the
  container.

Fixes https://github.com/yugabyte/yugabyte-db/issues/9006