### PR TITLE
[PLAT-2031] Add rootCA checksum to yb-masters and yb-tservers statefulsets

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -161,16 +161,22 @@ spec:
   template:
     metadata:
       {{- if eq .name "yb-masters" }}
-      {{- if (or $root.Values.networkAnnotation $root.Values.master.podAnnotations) }}
+      {{- if (or $root.Values.networkAnnotation $root.Values.master.podAnnotations $root.Values.tls.enabled) }}
       annotations:
       {{- with $root.Values.networkAnnotation }}{{ toYaml . | nindent 8 }}{{ end }}
       {{- with $root.Values.master.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
+      {{- if $root.Values.tls.enabled }}
+        checksum/rootCA: {{ cat $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key | sha256sum }}
+      {{- end }}
       {{- end }}
       {{- else }}
-      {{- if (or $root.Values.networkAnnotation $root.Values.tserver.podAnnotations) }}
+      {{- if (or $root.Values.networkAnnotation $root.Values.tserver.podAnnotations $root.Values.tls.enabled) }}
       annotations:
       {{- with $root.Values.networkAnnotation }}{{ toYaml . | nindent 8 }}{{ end }}
       {{- with $root.Values.tserver.podAnnotations }}{{ toYaml . | nindent 8 }}{{ end }}
+      {{- if $root.Values.tls.enabled }}
+        checksum/rootCA: {{ cat $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key | sha256sum }}
+      {{- end }}
       {{- end }}
       {{- end }}
       labels:


### PR DESCRIPTION
This diff is a prerequisite for k8s cert rotation changes.
Added rootCA checksum to the yb-masters and yb-tservers statefulsets
So that pods are restarted when we introduce any change in the rootCA

Test Plan:
Tested locally along with k8s cert rotation changes.