### PR TITLE
[Platform] Added HTTP to HTTPS redirection in nginx conf

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -156,6 +156,7 @@ metadata:
 data:
   default.conf: |
 {{- if .Values.tls.enabled }}
+    # Ref: https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/
     server {
       listen  {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:8080" "8080" }};
       server_name {{ .Values.tls.hostname }};
@@ -172,13 +173,15 @@ data:
       ssl_protocols {{ include "validate_nginx_ssl_protocols" . }};
 {{- end }}
       server_name  {{ .Values.tls.hostname }};
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 {{- else }}
       listen       {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:8080" "8080" }};
       server_name  {{ .Values.tls.hostname }};
 {{- end }}
       proxy_http_version 1.1;
       proxy_set_header X-Real-IP  $remote_addr;
-      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header Host $host;
 
       location / {

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -155,6 +155,14 @@ metadata:
     heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
 data:
   default.conf: |
+{{- if .Values.tls.enabled }}
+    server {
+      listen  {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:8080" "8080" }};
+      server_name {{ .Values.tls.hostname }};
+      return  301  https://$host$request_uri;
+    }  
+{{- end }}
+
     server {
 {{- if .Values.tls.enabled }}
       listen       8443 ssl;

--- a/stable/yugaware/templates/service.yaml
+++ b/stable/yugaware/templates/service.yaml
@@ -24,14 +24,14 @@ spec:
 {{- end }}
 {{- end }}
   ports:
-  - name: ui
 {{- if .Values.tls.enabled }}
+  - name: ui-tls
     port: 443
     targetPort: 8443
-{{- else }}
+{{- end }}
+  - name: ui
     port: 80
     targetPort: 8080
-{{- end }}
   - name: metrics
     port: 9090
   selector:


### PR DESCRIPTION
### Summary
 
- We have made these changes because it redirects to the HTTP after integration in a few of the SSO or OIDC integration.
And previously, we disabled the HTTP traffic totally once we enabled the TLS. But after these changes, it'll redirect the HTTP traffic to HTTPS in case TLS enabled deployment.

### Test
- Tested the HTTP redirection to HTTPS. 
- Tested the upgrade of TLS enabled installation,