### PR TITLE
[plat-3597] Added volume legacy annotations to support old universe upgrade

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -145,12 +145,16 @@ spec:
     {{- range $index := until (int ($storageInfo.count )) }}
     - metadata:
         name: {{ $root.Values.oldNamingStyle | ternary (printf "datadir%d" $index) (printf "%s%d" (include "yugabyte.volume_name" $root) $index) }}
+        {{- if $root.Values.legacyVolumeClaimAnnotations }}
+        annotations:
+          volume.beta.kubernetes.io/storage-class: {{ $storageInfo.storageClass | quote }}
+        {{- end }}
         labels:
           {{- include "yugabyte.labels" $root | indent 10 }}
       spec:
         accessModes:
           - "ReadWriteOnce"
-        {{- if $storageInfo.storageClass }}
+        {{- if or $root.Values.legacyVolumeClaimAnnotations $storageInfo.storageClass }}
         storageClassName: {{ $storageInfo.storageClass }}
         {{- end }}
         resources:

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -154,7 +154,7 @@ spec:
       spec:
         accessModes:
           - "ReadWriteOnce"
-        {{- if or $root.Values.legacyVolumeClaimAnnotations $storageInfo.storageClass }}
+        {{- if $storageInfo.storageClass }}
         storageClassName: {{ $storageInfo.storageClass }}
         {{- end }}
         resources:

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -330,3 +330,7 @@ podSecurityContext:
   fsGroup: 10001
   runAsUser: 10001
   runAsGroup: 10001
+
+## Added to handle old universe which has volume annotations
+## K8s universe <= 2.5 to >= 2.6
+legacyVolumeClaimAnnotations: false


### PR DESCRIPTION
### Summary

- We have volume annotations in the YugabyteDB old Helm chart versions. We removed them in newer versions, so the old deployed universes cannot be upgraded because we can't change the volume annotations once set.
- We have provided a flag that enables us to set the old legacy volume annotations. 
- The value of storageClass in these old installations comes from the provider in Yugabyte Platform, so the value of `storage.master/tserver.storageClass` will be set to `standard` (old default value in platform) or the user provided value. Reference: https://github.com/yugabyte/yugabyte-db/commit/acb23dd475637b40af7b7e613dc47a8409042653

### Tests
1. Install the universe using Yugabyte DB v2.4.0 charts and upgrade it using the changes. I have used the following commands to test it.

```sh
helm install yb-db-test yugabytedb/yugabyte -n yb-db \
    --set Image.tag=2.4.1.2-b3 \
    --version 2.4.1

helm upgrade yb-db-test stable/yugabyte -n yb-db \
    --set storage.master.storageClass=standard \
    --set storage.tserver.storageClass=standard \
    --set Image.tag=2.13.0.0-b42 \
    --set legacyVolumeClaimAnnotations=true \
    --version 2.13.0
```

2. Regular installation with `legacyVolumeClaimAnnotations=false` are working as intended. No change.
3. Regular installation with `legacyVolumeClaimAnnotations=true` and `StorageClass=xyz` will set the annotation and `xyz` as its value.
4. Regular installation with custom StorageClass work as intended.
5. Regular installation with `legacyVolumeClaimAnnotations=true` and without StorageClass, will set empty value annotation.