### PR TITLE
[Backport 2.12][plat-3597] Added volume legacy annotations to support…

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -134,6 +134,10 @@ spec:
     {{- range $index := until (int ($storageInfo.count )) }}
     - metadata:
         name: {{ $root.Values.oldNamingStyle | ternary (printf "datadir%d" $index) (printf "%s%d" (include "yugabyte.volume_name" $root) $index) }}
+        {{- if $root.Values.legacyVolumeClaimAnnotations }}
+        annotations:
+          volume.beta.kubernetes.io/storage-class: {{ $storageInfo.storageClass | quote }}
+        {{- end }}
         labels:
           {{- include "yugabyte.labels" $root | indent 10 }}
       spec:

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -309,3 +309,7 @@ preflight:
   skipAll: false
   # Set to true to skip port bind checks
   skipBind: false
+
+## Added to handle old universe which has volume annotations
+## K8s universe <= 2.5 to >= 2.6
+legacyVolumeClaimAnnotations: false


### PR DESCRIPTION
… old universe upgrade (#130)

* [plat-3597] Added volume legacy annotations to support old universe
upgrade

Tests -
1. Install the universe using Yugabyte DB v2.4.0 charts and upgrade it
using the the changes. I have used the following commands to test it.

helm install yb-db-test yugabytedb/yugabyte -n yb-db \
    --set Image.tag=2.4.1.2-b3 \
    --version 2.4.1

helm upgrade yb-db-test stable/yugabyte -n yb-db \
    --set storage.master.storageClass=standard \
    --set storage.tserver.storageClass=standard \
    --set Image.tag=2.13.0.0-b42 \
    --set legacyVolumeClaimAnnotations=true \
    --version 2.13.0

2. Regular installation with legacyVolumeClaimAnnotations=false are working as intended. No change.
3. Regular installation with legacyVolumeClaimAnnotations=true and
StorageClass, it'll create the universe and set the annotation and SC as the value of it.
4. Regular installation with custom StorageClass work as intended.
5. Regular installation with legacyVolumeClaimAnnotations=true, will set
empty value annotation.