### PR TITLE
[Backport 2.12][Plat-3409][k8s] Run yugabyte as non root user (#129)

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -187,6 +187,9 @@ spec:
       imagePullSecrets:
       - name: {{ $root.Values.Image.pullSecretName }}
       {{ end }}
+      {{- if $root.Values.podSecurityContext.enabled }}
+      securityContext: {{- omit $root.Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       {{- if $root.Values.nodeSelector }}
       nodeSelector:
       {{ toYaml $root.Values.nodeSelector | indent 8 }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -309,3 +309,14 @@ preflight:
   skipAll: false
   # Set to true to skip port bind checks
   skipBind: false
+
+## Pod securityContext
+## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
+## The following configuration runs YB-Master and YB-TServer as a non-root user
+podSecurityContext:
+  enabled: false
+  ## Mark it false, if you want to stop the non root user validation
+  runAsNonRoot: true
+  fsGroup: 10001
+  runAsUser: 10001
+  runAsGroup: 10001


### PR DESCRIPTION
* [Plat-3409][k8s] Run yugabyte as non-root user

Test -
I used the changes to deploy TLS enabled & non-TLS universes and tested them with ysqlsh & ycqlsh on K8s, and it's working fine.
For OCP, either we need to provide the user ID, fsgroup and group ID as per the OCP projects configuration OR
keep the charts' based security context disabled and let them (OCP) add on their own.

Current changes won't support helm upgrade from root to non-root users.

* Update stable/yugabyte/values.yaml