### PR TITLE
[PLAT-3560][PLAT-3950] Add ability to run platform as a non-root user

### DIFF
--- a/stable/yugaware/templates/init-container-script.yaml
+++ b/stable/yugaware/templates/init-container-script.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.securityContext.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-yugaware-init-container
+  labels:
+    app: {{ template "yugaware.name" . }}
+    chart: {{ template "yugaware.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Values.helm2Legacy | ternary "Tiller" (.Release.Service | quote) }}
+data:
+  init-permissions.sh: |
+    #!/bin/bash
+
+    set -xe
+
+    directory_name="/opt/yugabyte/yugaware/data"
+    pemfiles=$(find "${directory_name}/keys/" -name "*.pem" -exec stat -c "%a" {} + | uniq | tr '\n' ',')
+    IFS="," read -r -a array <<< "$pemfiles"
+    
+    trigger=false
+    echo "Finding pem files without 400 permission"
+    
+    for pemfile in  "${array[@]}"
+    do
+      echo "pemfile - $pemfile"
+      if [[ "$pemfile" != *400* ]]; then
+        echo "pemfile - $pemfile"
+        trigger=true
+        break
+      fi
+    done
+    
+    if ${trigger}; then
+      echo "Creating copy of data/keys directory"
+      cp -r "${directory_name}/keys" "${directory_name}/new_keys"
+
+      echo "Setting permission to all pem files to 400"
+      find "${directory_name}/new_keys/" -name "*.pem" -exec chmod 400 {} +
+
+      echo "Renaming old keys directory"
+      mv "${directory_name}/keys" "${directory_name}/keys-$(date +%s)"
+
+      echo "Renaming new keys directory"
+      mv "${directory_name}/new_keys" "${directory_name}/keys"
+    else
+      echo "Does not find pem file without 400 permission"
+    fi
+{{- end }}

--- a/stable/yugaware/templates/init-container-script.yaml
+++ b/stable/yugaware/templates/init-container-script.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-yugaware-init-container
+  name: {{ .Release.Name }}-yugaware-init
   labels:
     app: {{ template "yugaware.name" . }}
     chart: {{ template "yugaware.chart" . }}
@@ -12,20 +12,18 @@ data:
   init-permissions.sh: |
     #!/bin/bash
 
-    set -xe
+    set -xe -o pipefail
 
-    directory_name="/opt/yugabyte/yugaware/data"
-    pemfiles=$(find "${directory_name}/keys/" -name "*.pem" -exec stat -c "%a" {} + | uniq | tr '\n' ',')
-    IFS="," read -r -a array <<< "$pemfiles"
+    data_directory="/opt/yugabyte/yugaware/data"
+    pemfiles=$(find "${data_directory}/keys/" -name "*.pem" -exec stat -c "%a" {} + | uniq | tr '\n' ',')
+    IFS="," read -r -a pemfile_perms <<< "${pemfiles}"
     
     trigger=false
-    echo "Finding pem files without 400 permission"
+    echo "Finding pem files with permissions different than 400, and setting their permissions to 400."
     
-    for pemfile in  "${array[@]}"
-    do
-      echo "pemfile - $pemfile"
-      if [[ "$pemfile" != *400* ]]; then
-        echo "pemfile - $pemfile"
+    for pemfile in  "${pemfile_perms[@]}"; do
+      if [[ "${pemfile}" != *400* ]]; then
+        echo "Found a pem file with permissions ${pemfile}"
         trigger=true
         break
       fi
@@ -33,17 +31,17 @@ data:
     
     if ${trigger}; then
       echo "Creating copy of data/keys directory"
-      cp -r "${directory_name}/keys" "${directory_name}/new_keys"
+      cp -r "${data_directory}/keys" "${data_directory}/new_keys"
 
-      echo "Setting permission to all pem files to 400"
-      find "${directory_name}/new_keys/" -name "*.pem" -exec chmod 400 {} +
+      echo "Setting permission of all pem files to 400"
+      find "${data_directory}/new_keys/" -name "*.pem" -exec chmod 400 {} +
 
-      echo "Renaming old keys directory"
-      mv "${directory_name}/keys" "${directory_name}/keys-$(date +%s)"
+      echo "Renaming existing keys directory"
+      mv "${data_directory}/keys" "${data_directory}/keys-$(date +%s)"
 
       echo "Renaming new keys directory"
-      mv "${directory_name}/new_keys" "${directory_name}/keys"
+      mv "${data_directory}/new_keys" "${data_directory}/keys"
     else
-      echo "Does not find pem file without 400 permission"
+      echo "All pem files already have permission set to 400"
     fi
 {{- end }}

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -82,10 +82,30 @@ spec:
         - image: {{ include "full_yugaware_image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: prometheus-configuration
-          command: ["cp", "/default_prometheus_config/prometheus.yml", "/prometheus_configs/prometheus.yml"]
+          command:
+            - 'bash'
+            - '-c'
+            - >
+              cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml;
+              echo "finding pem files with 660 permission";
+              directory_name="/opt/yugabyte/yugaware/data";
+              pemfiles=$(find "$directory_name"/keys/** -name "*.pem" -exec stat -c "%a" {} +);
+              if [[ $pemfiles == *660* ]]; then
+                echo "creating new key directory";
+                mkdir "$directory_name"/new_keys;
+                echo "copying content of data/key/* to new keys directory";
+                cp -r "$directory_name"/keys/* "$directory_name"/new_keys/;
+                echo "setting permission to all pem files to 600";
+                find "$directory_name"/new_keys/** -name "*.pem" -exec chmod 600 {} +;
+                echo "Renaming old keys directory";
+                mv "$directory_name"/keys "$directory_name"/keys-"$(date +%s)";
+                echo "Renaming new keys directory";
+                mv "$directory_name"/new_keys "$directory_name"/keys;
+              else
+                echo "Does not find pem file with 660 permission";
+              fi;
           {{- if .Values.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.securityContext.runAsUser }}
+          securityContext: {{- omit .Values.securityContext "enabled" "fsGroup" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
           - name: prometheus-config
@@ -93,6 +113,9 @@ spec:
           - name: yugaware-storage
             mountPath: /prometheus_configs
             subPath: prometheus.yml
+          - name: yugaware-storage
+            mountPath: /opt/yugabyte/yugaware/data/
+            subPath: data
       containers:
         {{ if not .Values.postgres.external.host }}
         - name: postgres
@@ -133,7 +156,9 @@ spec:
         - name: prometheus
           image: {{ include "full_image" (dict "containerName" "prometheus" "root" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if (not .Values.ocpCompatibility.enabled) }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext: {{- omit .Values.securityContext "enabled" "fsGroup"  | toYaml | nindent 12 }}
+          {{- else if (not .Values.ocpCompatibility.enabled) }}
           securityContext:
             runAsUser: 0
           {{- end }}
@@ -170,8 +195,7 @@ spec:
         - name: yugaware
           image: {{ include "full_yugaware_image" . }}
           {{- if .Values.securityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.securityContext.runAsUser }}
+          securityContext: {{- omit .Values.securityContext "enabled" "fsGroup" | toYaml | nindent 12 }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
         {{- if .Values.securityContext.enabled }}
         - name: init-container-script
           configMap:
-            name: {{ .Release.Name }}-yugaware-init-container
+            name: {{ .Release.Name }}-yugaware-init
             items:
               - key: init-permissions.sh
                 path: init-permissions.sh

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -32,6 +32,9 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
+        {{- if (semverCompare ">=1.20-x" .Capabilities.KubeVersion.Version) }}
+        fsGroupChangePolicy: {{ .Values.securityContext.fsGroupChangePolicy }}
+        {{- end }}
       {{- end }}
       volumes:
         - name: yugaware-storage
@@ -72,7 +75,14 @@ spec:
             items:
               - key: prometheus.yml
                 path: prometheus.yml
-
+        {{- if .Values.securityContext.enabled }}
+        - name: init-container-script
+          configMap:
+            name: {{ .Release.Name }}-yugaware-init-container
+            items:
+              - key: init-permissions.sh
+                path: init-permissions.sh
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: {{  .Release.Name }}-yugaware-tls-cert
           secret:
@@ -82,30 +92,19 @@ spec:
         - image: {{ include "full_yugaware_image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: prometheus-configuration
+          {{- if .Values.securityContext.enabled }}
           command:
             - 'bash'
             - '-c'
             - >
               cp /default_prometheus_config/prometheus.yml /prometheus_configs/prometheus.yml;
-              echo "finding pem files with 660 permission";
-              directory_name="/opt/yugabyte/yugaware/data";
-              pemfiles=$(find "$directory_name"/keys/** -name "*.pem" -exec stat -c "%a" {} +);
-              if [[ $pemfiles == *660* ]]; then
-                echo "creating new key directory";
-                mkdir "$directory_name"/new_keys;
-                echo "copying content of data/key/* to new keys directory";
-                cp -r "$directory_name"/keys/* "$directory_name"/new_keys/;
-                echo "setting permission to all pem files to 600";
-                find "$directory_name"/new_keys/** -name "*.pem" -exec chmod 600 {} +;
-                echo "Renaming old keys directory";
-                mv "$directory_name"/keys "$directory_name"/keys-"$(date +%s)";
-                echo "Renaming new keys directory";
-                mv "$directory_name"/new_keys "$directory_name"/keys;
-              else
-                echo "Does not find pem file with 660 permission";
-              fi;
-          {{- if .Values.securityContext.enabled }}
-          securityContext: {{- omit .Values.securityContext "enabled" "fsGroup" | toYaml | nindent 12 }}
+              bash /init-container/init-permissions.sh;
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          {{- else }}
+          command: ["cp", "/default_prometheus_config/prometheus.yml", "/prometheus_configs/prometheus.yml"]
           {{- end }}
           volumeMounts:
           - name: prometheus-config
@@ -113,9 +112,13 @@ spec:
           - name: yugaware-storage
             mountPath: /prometheus_configs
             subPath: prometheus.yml
+          {{- if .Values.securityContext.enabled }}
           - name: yugaware-storage
             mountPath: /opt/yugabyte/yugaware/data/
             subPath: data
+          - name: init-container-script
+            mountPath: /init-container
+          {{- end }}
       containers:
         {{ if not .Values.postgres.external.host }}
         - name: postgres
@@ -157,7 +160,10 @@ spec:
           image: {{ include "full_image" (dict "containerName" "prometheus" "root" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.securityContext.enabled }}
-          securityContext: {{- omit .Values.securityContext "enabled" "fsGroup"  | toYaml | nindent 12 }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           {{- else if (not .Values.ocpCompatibility.enabled) }}
           securityContext:
             runAsUser: 0
@@ -195,7 +201,10 @@ spec:
         - name: yugaware
           image: {{ include "full_yugaware_image" . }}
           {{- if .Values.securityContext.enabled }}
-          securityContext: {{- omit .Values.securityContext "enabled" "fsGroup" | toYaml | nindent 12 }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.securityContext.runAsGroup }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -118,6 +118,7 @@ securityContext:
   runAsUser: 10001
   runAsGroup: 10001
   runAsNonRoot: true
+  fsGroupChangePolicy: "OnRootMismatch"
 
 helm:
   timeout: 900

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -114,11 +114,14 @@ tls:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   enabled: false
+  ## fsGroup related values are set at the pod level.
   fsGroup: 10001
+  fsGroupChangePolicy: "OnRootMismatch"
+  ## The following values are set for yugaware and prometheus
+  ## containers.
   runAsUser: 10001
   runAsGroup: 10001
   runAsNonRoot: true
-  fsGroupChangePolicy: "OnRootMismatch"
 
 helm:
   timeout: 900

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -114,8 +114,10 @@ tls:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext:
   enabled: false
-  fsGroup: 1001
-  runAsUser: 1001
+  fsGroup: 10001
+  runAsUser: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
 
 helm:
   timeout: 900


### PR DESCRIPTION
### Summary 
- Supports to run platform as a non-root user.
- Supports the platform upgrade from root user to a non-root user.
- Supports the platform upgrade from 1001 user to a 10001 user.
- Added the script in the init container to handle the SSH keys permission issue while restarting.

### Test plan
1. Deploy the platform using the chart changes with the security context enabled and able to spin up the K8s and GCP VM based universes successfully.
2. Generated the template by chart changes, and without chart changes and comparison look good, which means changes won't impact the regular deployment flow.
3. Deployed the platform v2.12.3.0-b19 [Chart v2.12.3] and configured the GCP cloud provider. Then upgraded it to the platform v2.13.3.0-b117 along with chart changes with security context enabled and successfully deployed the VM based universes.
4. To test the init container script - Deployed the platform using the changes and configured the GCP Cloud provider. Restarted the sts using the helm rollout command. The script worked as intended and was able to deploy VM based universe successfully.

## 2 commit - Moved the init-container script to ConfigMap
### Summary

- Added `fsGroupPolicyChange` in charts. However, Chart will add it only on clusters above or equal to v1.20.
- The Chart will create ConfigMap for init-container-script only when we have security context enabled on the Platform. 

### Test Plan
1. Test sts rollout on 1.19 GKE cluster

- I spun up a 1.19 GKE cluster and deployed the Platform running as non-root using chart changes. Changes won't add `fsGroupPolicyChange` because v1.19 does not have that feature. 
- Configured the GCP Cloud provider and created one certificate in Security Tab. 
- Restart the STS that updates the permissions of SSH keys. However, the init-container script will take this up as a trigger and change the permissions of all SSH keys to 400 to resolve the permission issue. 
- Successfully created the VM-based universe using the previously configured provider and TLS certs & added one more node after universe creation. 

2. Upgrade test from Platfrom v2.12 [root] to v2.13 [non-root] on GKE v1.22. 

- I deployed the Platform as root using Chart v2.12.3 and Platform image 2.12.3.0-b19. 
- Configured the GCP Cloud provider and created one certificate in Security Tab. 
- I upgraded the Platform using the changes as non-root and v2.13. Chart added `fsGroupPolicyChange`, but `fsGroup` updated the permission because the directory owner doesn't match, so `fsGroupPolicyChange` won't prevent us from SSH permission issue in this case. However, the init-script captures this event and changes the permissions of all SSH keys to 400 to resolve the permission issue of SSH keys.
- Successfully created the VM-based universe using the previously configured provider and TLS certs & added one more node after universe creation. 

3. This change won't impact regular deployment because it needs `securityContext.enabled: true` to run the Platform as non-root. By default, we kept it false. 

