### PR TITLE
Update find_docker_tag.py

### DIFF
--- a/.ci/find_docker_tag.py
+++ b/.ci/find_docker_tag.py
@@ -19,7 +19,7 @@ def main(release):
     json_response = response.json()
 
     tags = dict()
-    for tag_obj in json_response:
+    for tag_obj in json_response['results']:
         tag = tag_obj['name']
         if tag.startswith(release.version):
             build_number = int(tag[tag.rindex("-b")+2:])

--- a/.ci/find_docker_tag.py
+++ b/.ci/find_docker_tag.py
@@ -5,7 +5,7 @@ from re import match
 from requests import request
 from sys import exit
 
-DOCKER_TAGS_URL = "https://registry.hub.docker.com/v1/repositories/yugabytedb/yugabyte/tags"
+DOCKER_TAGS_URL = "https://registry.hub.docker.com/v2/repositories/yugabytedb/yugabyte/tags"
 
 
 def main(release):


### PR DESCRIPTION
Switch to v2 of the docker tag registry, v1 seems to be gone.