### PR TITLE
Update find_docker_tag.py

### DIFF
--- a/.ci/find_docker_tag.py
+++ b/.ci/find_docker_tag.py
@@ -5,7 +5,7 @@ from re import match
 from requests import request
 from sys import exit
 
-DOCKER_TAGS_URL = "https://registry.hub.docker.com/v1/repositories/yugabytedb/yugabyte/tags"
+DOCKER_TAGS_URL = "https://registry.hub.docker.com/v2/repositories/yugabytedb/yugabyte/tags"
 
 
 def main(release):


### PR DESCRIPTION
Switch to v2 of the docker tag registry, v1 seems to be gone.