### PR TITLE
[PLAT-5259][Platform] Update version in master branch

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -74,3 +74,28 @@ jobs:
         git status
         git diff
         exit 1
+    - name: "Switch to master branch"
+      id: switch-to-master-branch
+      run: |
+        git checkout master
+    - name: "Update the master version if needed."
+      id: update-master-version
+      continue-on-error: true
+      run: |
+        # Following script updates files only if higher version is passed.
+        .ci/update_version.sh '${{steps.extract-version.outputs.yb_version}}'
+    - name: "Push the changes to master branch"
+      if: steps.update-master-version.outcome == 'success'
+      run: |
+        git status
+        git diff
+        git add ./stable/yugabyte/Chart.yaml ./stable/yugaware/Chart.yaml \
+                ./stable/yugabyte/values.yaml ./stable/yugaware/values.yaml ./stable/yugabyte/app-readme.md
+        git commit -m "Update the version to ${{steps.extract-version.outputs.yb_version}}"
+        git push origin HEAD:master
+    - name: "Show git status in case of failure"
+      if: steps.update-master-version.outcome == 'failure'
+      run: |
+        git status
+        git diff
+        exit 1


### PR DESCRIPTION
 Github workflow script to update the version for yugabyte/yugaware is broken.

Summary:
We were not updating version in master branch. This change updates master branch if there is higher version than already present in the master branch.

Test Plan:
Tested by sending a custom repository dispatch event using curl on a private fork. 
Comment https://github.com/yugabyte/charts/pull/150#issuecomment-1487401640
Describes the result of the test.


The script gets triggered if there is repository_dispatch event. It will update existing branch and master branch versions.

Reviewers: sanketh, nsingh