### PR TITLE
[PLAT-5675][Platform] Map extra k8s secret to yb db pods in Platform-created namespace.

### DIFF
--- a/stable/yugabyte/templates/secrets.yaml
+++ b/stable/yugabyte/templates/secrets.yaml
@@ -1,0 +1,7 @@
+{{- $root := . -}}
+--- # Create secrets from other namespaces for masters.
+{{- $data := dict "secretenv" $.Values.master.secretEnv "root" . "suffix" "master"}}
+{{- include "yugabyte.envsecrets" $data }}
+--- # Create secrets from other namespaces for tservers.
+{{- $data := dict "secretenv" $.Values.tserver.secretEnv "root" . "suffix" "tserver" }}
+{{- include "yugabyte.envsecrets" $data }}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -24,7 +24,7 @@ data:
 {{- end }}
 ---
 {{- end }}
-
+---
 {{- range .Values.Services }}
 {{- $service := . -}}
 {{- $appLabelArgs := dict "label" .label "root" $root -}}
@@ -337,18 +337,20 @@ spec:
         - name: YBDEVOPS_CORECOPY_DIR
           value: "/mnt/disk0/cores"
         {{- if eq .name "yb-masters" }}
-        {{- with $root.Values.master.extraEnv }}{{ toYaml . | nindent 8 }}{{ end }}
-        {{- with $root.Values.master.secretEnv }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- with $root.Values.master.extraEnv }}{{ toYaml . | nindent 8 }}{{- end }}
+        {{- $data := dict "secretenv" $root.Values.master.secretEnv "root" $root "suffix" "master"}}
+        {{- include "yugabyte.addenvsecrets" $data | nindent 8 }}
         {{- else }}
-        {{- with $root.Values.tserver.extraEnv }}{{ toYaml . | nindent 8 }}{{ end }}
-        {{- with $root.Values.tserver.secretEnv }}{{ toYaml . | nindent 8 }}{{ end }}
+        {{- with $root.Values.tserver.extraEnv }}{{ toYaml . | nindent 8 }}{{- end }}
+        {{- $data := dict "secretenv" $root.Values.tserver.secretEnv "root" $root "suffix" "tserver" }}
+        {{- include "yugabyte.addenvsecrets" $data | nindent 8 }}
         {{- end }}
         {{- if and $root.Values.tls.enabled $root.Values.tls.clientToServer (ne .name "yb-masters") }}
         - name: SSL_CERTFILE
           value: /root/.yugabytedb/root.crt
         {{- end }}
         resources:
-        {{ if eq .name "yb-masters" }}
+        {{- if eq .name "yb-masters" }}
 {{ toYaml $root.Values.resource.master | indent 10 }}
         {{ else }}
 {{ toYaml $root.Values.resource.tserver | indent 10 }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -371,13 +371,16 @@ tserver:
   #       fieldPath: status.hostIP
   extraEnv: []
 
-  # secretEnv variables are used to expose secrets data as env variables in the tserver pods.
-  # TODO Add namespace also to support copying secrets from other namespace.
+  ## secretEnv variables are used to expose secrets data as env variables in the tserver pods.
+  ## If namespace field is not specified we assume that user already
+  ## created the secret in the same namespace as DB pods.
+  ## Example
   # secretEnv:
   # - name: MYSQL_LDAP_PASSWORD
   #   valueFrom:
   #     secretKeyRef:
   #       name: secretName
+  #       namespace: my-other-namespace-with-ldap-secret
   #       key: password
   secretEnv: []
 


### PR DESCRIPTION

Summary:
We create secrets from other namespaces if required for master.secretEnv and tserver.secretEnv. We mangle names to make unique secret names by following the [doc](https://docs.google.com/document/d/1rGoy2pTaUXI7NfjDCi02Cdq1UeJoCyQEKy6uykKqwlo/edit?pli=1# ).
If two same secrets are mentioned in both master/tserver secretEnv we create two separate secrets.

Only helm chart changes are needed for this feature.

Helm chart installation fails if namespace/secret/key doesn't exist (if optional is not set) or if permissions are not there to look up secrets from different namespace.

If same secret is specified in master.secretEnv (or tserver.secretEnv) more than once, installation fails. We are not catching this as of now.

Test Plan:
Manually tested following scenarios.
In values.yaml I gave
```
  secretEnv:
  - name: envusername
    valueFrom:
      secretKeyRef:
        name: secret-basic-auth
        key: username
        namespace: yb-admin-gjalla-test
        optional: true
```
 and ran helm install and saw the secret "yw-yb-ad-secre-usern-23a9-master" getting created in universe namespace. Tried out error cases like
Specified a secret that doesn't exist with optional set to false - fails with message "Secret or key missing for secret-basic-auth/user_name in namespace: yb-admin-gjalla-test"
master.secretEnv and tserver.secretEnv having same secrets - installation succeeds as we create two different secrets (they differ in suffix names)
master.secretEnv having same entry twice - fails with "secrets "yw-yb-ad-secre-usern-23a9-master" already exists"

Reviewers: sanketh, nsingh, bgandhi

Subscribers: yugaware