### PR TITLE
[PLAT-5753] Added metric name relabeling for CPU metric

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -441,7 +441,7 @@ data:
             target_label: "__name__"
             replacement: "kube_pod_container_resource_requests_cpu_cores"
           # Keep metrics for CPU, discard duplicate metrics
-          - source_labels: ["saved_name"]
+          - source_labels: ["__name__"]
             regex: "kube_pod_container_resource_requests_cpu_cores"
             action: keep
 

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -164,7 +164,7 @@ data:
       listen  {{ eq .Values.ip_version_support "v6_only" | ternary "[::]:8080" "8080" }};
       server_name {{ .Values.tls.hostname }};
       return  301  https://$host$request_uri;
-    }  
+    }
 {{- end }}
 
     server {
@@ -415,7 +415,7 @@ data:
         metric_relabel_configs:
           # Only keep the metrics which we care about
           - source_labels: ["__name__"]
-            regex: "kube_pod_container_resource_requests_cpu_cores"
+            regex: "kube_pod_container_resource_requests(_cpu_cores|)"
             action: keep
           # Save the name of the metric so we can group_by since we cannot by __name__ directly...
           - source_labels: ["__name__"]
@@ -434,6 +434,12 @@ data:
           - source_labels: ["pod_name"]
             regex: "(.*)yb-(.*)"
             action: keep
+          # rename new name of the CPU metric to the old name and label
+          # ref: https://github.com/kubernetes/kube-state-metrics/blob/master/CHANGELOG.md#v200-alpha--2020-09-16
+          - source_labels: ["__name__", "unit"]
+            regex: "kube_pod_container_resource_requests;core"
+            target_label: "__name__"
+            replacement: "kube_pod_container_resource_requests_cpu_cores"
 
       - job_name: 'kubernetes-cadvisor'
 

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -411,7 +411,7 @@ data:
 
       - job_name: 'kube-state-metrics'
         static_configs:
-        - targets: ['kube-state-metrics.kube-system.svc.{{.Values.domainName}}:8080']
+        - targets: ['kube-state-metrics.kube-state.svc.{{.Values.domainName}}:8080']
         metric_relabel_configs:
           # Only keep the metrics which we care about
           - source_labels: ["__name__"]
@@ -440,6 +440,10 @@ data:
             regex: "kube_pod_container_resource_requests;core"
             target_label: "__name__"
             replacement: "kube_pod_container_resource_requests_cpu_cores"
+          # Keep metrics for CPU, discard duplicate metrics
+          - source_labels: ["saved_name"]
+            regex: "kube_pod_container_resource_requests_cpu_cores"
+            action: keep
 
       - job_name: 'kubernetes-cadvisor'
 

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -411,7 +411,7 @@ data:
 
       - job_name: 'kube-state-metrics'
         static_configs:
-        - targets: ['kube-state-metrics.kube-state.svc.{{.Values.domainName}}:8080']
+        - targets: ['kube-state-metrics.kube-system.svc.{{.Values.domainName}}:8080']
         metric_relabel_configs:
           # Only keep the metrics which we care about
           - source_labels: ["__name__"]


### PR DESCRIPTION
## Summary 
- Modified the config to keep new and old CPU metrics.
- Replaced the new metric name with the old one.

## Test plan
### Test - 1
- Spun up the EKS and deployed the platform using the `metric_relabel_config` change. Created the universe in the same namespace.
- Deployed the kube-state-metric with the latest version (2.7.0) and checked the CPU metrics on YBA UI.
- Having expected CPU metrics.

### Test - 2
- Used the following `bitnami/kube-state-metrics:1.9.7` image to verify the change with the older version. 
- Having expected CPU metrics.

fixes https://yugabyte.atlassian.net/browse/PLAT-5753

