### PR TITLE
[PLAT-9120] [yugabyte] Decouple istio and servicePerPod

### DIFF
--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -212,7 +212,7 @@ Generate server FQDN.
     {{ $membershipName := required "A valid membership name is required! Please set multicluster.kubernetesClusterId" .Values.multicluster.kubernetesClusterId }}
     {{- printf "$(HOSTNAME).%s.%s.$(NAMESPACE).svc.clusterset.local" $membershipName .Service.name -}}
   {{- else if .Values.oldNamingStyle -}}
-    {{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .Service.name .Values.domainName -}}  
+    {{- printf "$(HOSTNAME).%s.$(NAMESPACE).svc.%s" .Service.name .Values.domainName -}}
   {{- else -}}
     {{- if .Values.multicluster.createServiceExports -}}
       {{ $membershipName := required "A valid membership name is required! Please set multicluster.kubernetesClusterId" .Values.multicluster.kubernetesClusterId }}
@@ -267,7 +267,7 @@ Generate server web interface.
 Generate server CQL proxy bind address.
 */}}
 {{- define "yugabyte.cql_proxy_bind_address" -}}
-  {{- if or .Values.istioCompatibility.enabled .Values.multicluster.createServiceExports -}}
+  {{- if or .Values.istioCompatibility.enabled .Values.multicluster.createServiceExports .Values.multicluster.createServicePerPod -}}
     0.0.0.0:{{ index .Service.ports "tcp-yql-port" -}}
   {{- else -}}
     {{- include "yugabyte.server_fqdn" . -}}

--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -206,7 +206,7 @@ Get files from fs data directories for readiness / liveness probes.
 Generate server FQDN.
 */}}
 {{- define "yugabyte.server_fqdn" -}}
-  {{- if (and .Values.istioCompatibility.enabled .Values.multicluster.createServicePerPod) -}}
+  {{- if (or .Values.istioCompatibility.enabled .Values.multicluster.createServicePerPod) -}}
     {{- printf "$(HOSTNAME).$(NAMESPACE).svc.%s" .Values.domainName -}}
   {{- else if (and .Values.oldNamingStyle .Values.multicluster.createServiceExports) -}}
     {{ $membershipName := required "A valid membership name is required! Please set multicluster.kubernetesClusterId" .Values.multicluster.kubernetesClusterId }}

--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -243,13 +243,13 @@ we stick to 0.0.0.0, which works for master.
 */}}
 {{- define "yugabyte.rpc_bind_address" -}}
   {{- $port := index .Service.ports "tcp-rpc-port" -}}
-  {{- if (or .Values.istioCompatibility.enabled .Values.multicluster.createServicePerPod) -}}
+  {{- if .Values.istioCompatibility.enabled -}}
     {{- if (eq .Service.name "yb-masters") -}}
       0.0.0.0:{{ $port }}
     {{- else -}}
       $(POD_IP):{{ $port }},127.0.0.1:{{ $port }}
     {{- end -}}
-  {{- else if .Values.multicluster.createServiceExports -}}
+  {{- else if (or .Values.multicluster.createServiceExports .Values.multicluster.createServicePerPod) -}}
     $(POD_IP):{{ $port }}
   {{- else -}}
     {{- include "yugabyte.server_fqdn" . -}}

--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -206,7 +206,7 @@ Get files from fs data directories for readiness / liveness probes.
 Generate server FQDN.
 */}}
 {{- define "yugabyte.server_fqdn" -}}
-  {{- if (or .Values.istioCompatibility.enabled .Values.multicluster.createServicePerPod) -}}
+  {{- if .Values.multicluster.createServicePerPod -}}
     {{- printf "$(HOSTNAME).$(NAMESPACE).svc.%s" .Values.domainName -}}
   {{- else if (and .Values.oldNamingStyle .Values.multicluster.createServiceExports) -}}
     {{ $membershipName := required "A valid membership name is required! Please set multicluster.kubernetesClusterId" .Values.multicluster.kubernetesClusterId }}
@@ -267,7 +267,7 @@ Generate server web interface.
 Generate server CQL proxy bind address.
 */}}
 {{- define "yugabyte.cql_proxy_bind_address" -}}
-  {{- if or .Values.istioCompatibility.enabled .Values.multicluster.createServiceExports -}}
+  {{- if .Values.multicluster.createServiceExports -}}
     0.0.0.0:{{ index .Service.ports "tcp-yql-port" -}}
   {{- else -}}
     {{- include "yugabyte.server_fqdn" . -}}

--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -267,7 +267,7 @@ Generate server web interface.
 Generate server CQL proxy bind address.
 */}}
 {{- define "yugabyte.cql_proxy_bind_address" -}}
-  {{- if .Values.multicluster.createServiceExports -}}
+  {{- if or .Values.istioCompatibility.enabled .Values.multicluster.createServiceExports -}}
     0.0.0.0:{{ index .Service.ports "tcp-yql-port" -}}
   {{- else -}}
     {{- include "yugabyte.server_fqdn" . -}}

--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -243,7 +243,7 @@ we stick to 0.0.0.0, which works for master.
 */}}
 {{- define "yugabyte.rpc_bind_address" -}}
   {{- $port := index .Service.ports "tcp-rpc-port" -}}
-  {{- if .Values.istioCompatibility.enabled -}}
+  {{- if (or .Values.istioCompatibility.enabled .Values.multicluster.createServicePerPod) -}}
     {{- if (eq .Service.name "yb-masters") -}}
       0.0.0.0:{{ $port }}
     {{- else -}}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -385,8 +385,8 @@ spec:
           {{- $rpcPreflight := include "yugabyte.preflight_check" (set $serviceValues "Preflight" $rpcDict) -}}
           {{- if $rpcPreflight -}}{{ $rpcPreflight | nindent 12 }}{{ end -}}
           {{- $broadcastAddr := include "yugabyte.server_broadcast_address" $serviceValues -}}
-          {{/* skip bind check for Istio multi-cluster, we cannot/don't bind to service IP */}}
-          {{- if (not (or $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod)) }}
+          {{/* skip bind check for servicePerPod multi-cluster, we cannot/don't bind to service IP */}}
+          {{- if not $root.Values.multicluster.createServicePerPod }}
             {{- $broadcastPort := index $service.ports "tcp-rpc-port" -}}
             {{- $broadcastDict := dict "Addr" $broadcastAddr "Port" $broadcastPort -}}
             {{- $broadcastPreflight := include "yugabyte.preflight_check" (set $serviceValues "Preflight" $broadcastDict) -}}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -52,7 +52,7 @@ data:
   {{- $nodeNewStyle = printf "%s-%s-%d.%s.%s-%s.%s.svc.clusterset.local" (include "yugabyte.fullname" $root) $service.label $index $root.Values.multicluster.kubernetesClusterId (include "yugabyte.fullname" $root) $service.name $root.Release.Namespace }}
 {{- end -}}
 
-{{- if (and $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod) -}}
+{{- if (or $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod) -}}
   {{- $nodeOldStyle = printf "%s-%d.%s.svc.%s" $service.label $index $root.Release.Namespace $root.Values.domainName }}
   {{- $nodeNewStyle = printf "%s-%s-%d.%s.svc.%s" (include "yugabyte.fullname" $root) $service.label $index $root.Release.Namespace $root.Values.domainName }}
 {{- end -}}
@@ -64,7 +64,7 @@ data:
 {{- if $root.Values.multicluster.createServiceExports -}}
   {{- $dns1 = printf "*.%s.%s-%s.%s.svc.clusterset.local" $root.Values.multicluster.kubernetesClusterId (include "yugabyte.fullname" $root) $service.name $root.Release.Namespace }}
 {{- end -}}
-{{- if (and $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod) -}}
+{{- if (or $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod) -}}
   {{- $dns1 = printf "*.%s.svc.%s" $root.Release.Namespace $root.Values.domainName }}
 {{- end -}}
 {{- $rootCA := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}
@@ -386,7 +386,7 @@ spec:
           {{- if $rpcPreflight -}}{{ $rpcPreflight | nindent 12 }}{{ end -}}
           {{- $broadcastAddr := include "yugabyte.server_broadcast_address" $serviceValues -}}
           {{/* skip bind check for Istio multi-cluster, we cannot/don't bind to service IP */}}
-          {{- if (not (and $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod)) }}
+          {{- if (not (or $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod)) }}
             {{- $broadcastPort := index $service.ports "tcp-rpc-port" -}}
             {{- $broadcastDict := dict "Addr" $broadcastAddr "Port" $broadcastPort -}}
             {{- $broadcastPreflight := include "yugabyte.preflight_check" (set $serviceValues "Preflight" $broadcastDict) -}}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -52,7 +52,7 @@ data:
   {{- $nodeNewStyle = printf "%s-%s-%d.%s.%s-%s.%s.svc.clusterset.local" (include "yugabyte.fullname" $root) $service.label $index $root.Values.multicluster.kubernetesClusterId (include "yugabyte.fullname" $root) $service.name $root.Release.Namespace }}
 {{- end -}}
 
-{{- if (or $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod) -}}
+{{- if $root.Values.multicluster.createServicePerPod -}}
   {{- $nodeOldStyle = printf "%s-%d.%s.svc.%s" $service.label $index $root.Release.Namespace $root.Values.domainName }}
   {{- $nodeNewStyle = printf "%s-%s-%d.%s.svc.%s" (include "yugabyte.fullname" $root) $service.label $index $root.Release.Namespace $root.Values.domainName }}
 {{- end -}}
@@ -64,7 +64,7 @@ data:
 {{- if $root.Values.multicluster.createServiceExports -}}
   {{- $dns1 = printf "*.%s.%s-%s.%s.svc.clusterset.local" $root.Values.multicluster.kubernetesClusterId (include "yugabyte.fullname" $root) $service.name $root.Release.Namespace }}
 {{- end -}}
-{{- if (or $root.Values.istioCompatibility.enabled $root.Values.multicluster.createServicePerPod) -}}
+{{- if $root.Values.multicluster.createServicePerPod -}}
   {{- $dns1 = printf "*.%s.svc.%s" $root.Release.Namespace $root.Values.domainName }}
 {{- end -}}
 {{- $rootCA := buildCustomCert $root.Values.tls.rootCA.cert $root.Values.tls.rootCA.key -}}


### PR DESCRIPTION
Decoupling service per pod and Istio
This allow to create service per pod without adding the side car injection, for example if I don't want my DB to be on my service mesh but I need to the service per pod because I would like to use XCluster without the need of pod-to-pod communication and without MCS.

Or in case of YBA been in a different namespace than YB and cross-namespace communication is not allow.

