### PR TITLE
[PLAT-8544] Merge affinity rules correctly

### DIFF
--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -355,3 +355,51 @@ Set consistent issuer name.
       {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+  Default nodeAffinity for multi-az deployments
+*/}}
+{{- define "yugabyte.multiAZNodeAffinity" -}}
+requiredDuringSchedulingIgnoredDuringExecution:
+  nodeSelectorTerms:
+  - matchExpressions:
+    - key: failure-domain.beta.kubernetes.io/zone
+      operator: In
+      values:
+      - {{ .Values.AZ }}
+  - matchExpressions:
+    - key: topology.kubernetes.io/zone
+      operator: In
+      values:
+      - {{ .Values.AZ }}
+{{- end -}}
+
+{{/*
+  Default podAntiAffinity for master and tserver
+
+  This requires "appLabelArgs" to be passed in - defined in service.yaml
+  we have a .root and a .label in appLabelArgs
+*/}}
+{{- define "yugabyte.podAntiAffinity" -}}
+preferredDuringSchedulingIgnoredDuringExecution:
+- weight: 100
+  podAffinityTerm:
+    labelSelector:
+      matchExpressions:
+      {{- if .root.Values.oldNamingStyle }}
+      - key: app
+        operator: In
+        values:
+        - "{{ .label }}"
+      {{- else }}
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+        - "{{ .label }}"
+      - key: release
+        operator: In
+        values:
+        - {{ .Release.Name | quote }}
+      {{- end }}
+    topologyKey: kubernetes.io/hostname
+{{- end -}}

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -255,46 +255,35 @@ spec:
         # Set the anti-affinity selector scope to YB masters.
         {{ if $root.Values.AZ }}
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: failure-domain.beta.kubernetes.io/zone
-                operator: In
-                values:
-                - {{ $root.Values.AZ }}
-            - matchExpressions:
-              - key: topology.kubernetes.io/zone
-                operator: In
-                values:
-                - {{ $root.Values.AZ }}
+          {{- $baseAffinity := include "yugabyte.multiAZNodeAffinity" $root | fromYaml -}}
+          {{- if eq .name "yb-masters" -}}
+          {{- $mergedAffinity := get $root.Values.master.affinity "nodeAffinity" | default (dict) | mustMergeOverwrite $baseAffinity -}}
+          {{ toYaml $mergedAffinity | nindent 10}}
+          {{- else -}}
+          {{- $mergedAffinity := get $root.Values.tserver.affinity "nodeAffinity" | default (dict)  | mustMergeOverwrite $baseAffinity -}}
+          {{ toYaml $mergedAffinity | nindent 10}}
+          {{- end -}}
         {{ end }}
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                {{- if $root.Values.oldNamingStyle }}
-                - key: app
-                  operator: In
-                  values:
-                  - "{{ .label }}"
-                {{- else }}
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - "{{ .label }}"
-                - key: release
-                  operator: In
-                  values:
-                  - {{ $root.Release.Name | quote }}
-                {{- end }}
-              topologyKey: kubernetes.io/hostname
+          {{- $basePodAntiAffinity := include "yugabyte.podAntiAffinity" ($appLabelArgs) | fromYaml -}}
+          {{- if eq .name "yb-masters" -}}
+          {{- $mergedPodAntiAffinity := get $root.Values.master.affinity "podAntiAffinity" | default (dict) | mustMergeOverwrite $basePodAntiAffinity -}}
+          {{ toYaml $mergedPodAntiAffinity | nindent 10}}
+          {{- else -}}
+          {{- $mergedPodAntiAffinity := get $root.Values.tserver.affinity "podAntiAffinity" | default (dict)  | mustMergeOverwrite $basePodAntiAffinity -}}
+          {{ toYaml $mergedPodAntiAffinity | nindent 10}}
+          {{- end -}}
         {{- if eq .name "yb-masters" }}
-        {{- with $root.Values.master.affinity }}{{ toYaml . | nindent 8 }}{{ end }}
-        {{- else }}
-        {{- with $root.Values.tserver.affinity }}{{ toYaml . | nindent 8 }}{{ end }}
-        {{- end }}
+        {{- $affinity := omit $root.Values.master.affinity "nodeAffinity" "podAntiAffinity" -}}
+        {{- if $affinity -}}
+        {{ toYaml $affinity | nindent 8 }}
+        {{- end -}}
+        {{- else -}}
+        {{- $affinity := omit $root.Values.tserver.affinity "nodeAffinity" "podAntiAffinity" -}}
+        {{- if $affinity -}}
+        {{ toYaml $affinity | nindent 8 }}
+        {{- end -}}
+        {{ end }} 
       containers:
       - name: "{{ .label }}"
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"


### PR DESCRIPTION
Affinity rules were not merging correctly, allowing customers to fully overwrite nodeAffinity when they meant to add to it.

We now merge on both nodeAffinity and podAntiAffinity correctly. If a user desires, they are still able to overwrite fields within those, but it is not possible to add more affinity rules without overwriting the existing rules