### PR TITLE
[PLAT-8803] [YBA] Add extra volume support for postgres container

### DIFF
--- a/stable/yugaware/templates/_helpers.tpl
+++ b/stable/yugaware/templates/_helpers.tpl
@@ -193,3 +193,41 @@ Check export of nss_wrapper environment variables required
       {{- printf "false" -}}
   {{- end -}}
 {{- end -}}
+
+
+{{/*
+  Verify the extraVolumes and extraVolumeMounts mappings.
+  Every extraVolumes should have extraVolumeMounts
+*/}}
+{{- define "yugaware.isExtraVolumesMappingExists" -}}
+  {{- $lenExtraVolumes := len .extraVolumes -}}
+  {{- $lenExtraVolumeMounts := len .extraVolumeMounts -}}
+
+  {{- if and (eq $lenExtraVolumeMounts 0) (gt $lenExtraVolumes 0) -}}
+    {{- fail "You have not provided the extraVolumeMounts for extraVolumes." -}}
+  {{- else if and (eq $lenExtraVolumes 0) (gt $lenExtraVolumeMounts 0) -}}
+    {{- fail "You have not provided the extraVolumes for extraVolumeMounts." -}}
+  {{- else if and (gt $lenExtraVolumes 0) (gt $lenExtraVolumeMounts 0) -}}
+      {{- $volumeMountsList := list -}}
+      {{- range .extraVolumeMounts -}}
+        {{- $volumeMountsList = append $volumeMountsList .name -}}
+      {{- end -}}
+
+      {{- $volumesList := list -}}
+      {{- range .extraVolumes -}}
+        {{- $volumesList = append $volumesList .name -}}
+      {{- end -}}
+
+      {{- range $volumesList -}}
+        {{- if not (has . $volumeMountsList) -}}
+          {{- fail (printf "You have not provided the extraVolumeMounts for extraVolume %s" .) -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- range $volumeMountsList -}}
+        {{- if not (has . $volumesList) -}}
+          {{- fail (printf "You have not provided the extraVolumes for extraVolumeMounts %s" .) -}}
+        {{- end -}}
+      {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -157,6 +157,10 @@ spec:
             items:
               - key: postgresql.conf.sample
                 path: postgresql.conf.sample
+          {{- if .Values.postgres.extraVolumes -}}
+            {{- include "yugaware.isExtraVolumesMappingExists" .Values.postgres -}}
+            {{- .Values.postgres.extraVolumes | toYaml | nindent 8 -}}
+          {{ end }}
       initContainers:
         - image: {{ include "full_yugaware_image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -319,6 +323,10 @@ spec:
             - name: pg-sample-config
               mountPath: {{ .Values.image.postgres.sampleConfLocation }}
               subPath: postgresql.conf.sample
+         {{- if .Values.postgres.extraVolumeMounts -}}
+          {{- include "yugaware.isExtraVolumesMappingExists" .Values.postgres -}}
+          {{- .Values.postgres.extraVolumeMounts | toYaml | nindent 12 -}}
+        {{- end -}}
         {{ end }}
         - name: prometheus
           image: {{ include "full_image" (dict "containerName" "prometheus" "root" .) }}

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -163,6 +163,25 @@ postgres:
     ## JDBC connection parameters including the leading `?`.
     jdbcParams: ""
 
+  
+  ## Extra volumes
+  ## extraVolumesMounts are mandatory for each extraVolumes.
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#volume-v1-core
+  ## Example:
+  # extraVolumes:
+  # - name: custom-nfs-vol
+  #   persistentVolumeClaim:
+  #     claimName: some-nfs-claim
+  extraVolumes: []
+
+  ## Extra volume mounts
+  ## Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#volumemount-v1-core
+  ## Example:
+  # extraVolumeMounts:
+  # - name: custom-nfs-vol
+  #   mountPath: /home/yugabyte/nfs-backup
+  extraVolumeMounts: []
+
 tls:
   enabled: false
   hostname: "localhost"


### PR DESCRIPTION
On a system with huge_page enabled it seems more reasonable to just mount the huge page config into the container, that will avoid any issues that we can faced when trying to deactivate huge_page which doesn't seems to fully work anyway.


For example for the Postgres container with we disabled huge_page on the Postgres conf the container start but resource shared_buffer  400Kb and max_connections 20 seems limited, 


```
fixing permissions on existing directory /var/lib/postgresql/data/pgdata ... ok  
creating subdirectories ... ok                          
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 20                
selecting default shared_buffers ... 400kB              
selecting default time zone ... Etc/UTC                 
creating configuration files ... ok                     
running bootstrap script ... ok                         
performing post-bootstrap initialization ... ok     
```


When mounting the hugepage into the container we can see the shared_buffer and the max connections are ok
```
fixing permissions on existing directory /var/lib/postgresql/data/pgdata ..ok            
creating subdirectories ... ok                           
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 100               
selecting default shared_buffers ... 128MB              
selecting default time zone ... Etc/UTC                 
creating configuration files ... ok                     
running bootstrap script ... ok                         
performing post-bootstrap initialization ... ok         
syncing data to disk ... ok
``` 



To reproduce 

1- Create a EKS cluster
2- SSH to one of the node and enable hugepagee
```
echo "vm.nr_hugepages=256" >> /etc/sysctl.conf
sysctl -p
sudo systemctl restart kubelet
```
3- Deploy yba to the specific host with node selector

```
nodeSelector:
  kubernetes.io/hostname: hostname # you can check with kubectl get nodes --show-labels
```

`helm upgrade --install  yw-test yugabytedb/yugaware  --version 2.17.2 -n yb-platform --values your_yba-value.yml`

4- if you don't mount the hugepage you will see that YBA can be deployed because of max connections reached.

