### PR TITLE
Add possibility to config the ca issuer group and kind

### DIFF
--- a/stable/yugabyte/Chart.yaml
+++ b/stable/yugabyte/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: yugabyte
-version: 2.19.0
+version: 2.19.1
 appVersion: 2.19.0.0-b190
 kubeVersion: ">=1.17.0-0"
 home: https://www.yugabyte.com

--- a/stable/yugabyte/templates/certificates.yaml
+++ b/stable/yugabyte/templates/certificates.yaml
@@ -82,7 +82,12 @@ spec:
       {{- include "yugabyte.labels" $root | indent 6 }}
   issuerRef:
     name:  {{ include "yugabyte.tls_cm_issuer" $root | quote }}
-    {{- if $root.Values.tls.certManager.useClusterIssuer }}
+    {{- if $root.Values.tls.certManager.issuerRef.group }}
+    group: {{ $root.Values.tls.certManager.issuerRef.group }}
+    {{- end }}
+    {{- if $root.Values.tls.certManager.issuerRef.kind }}
+    kind: {{ $root.Values.tls.certManager.issuerRef.kind }}
+    {{- else if $root.Values.tls.certManager.useClusterIssuer }}
     kind: ClusterIssuer
     {{- else }}
     kind: Issuer
@@ -126,7 +131,12 @@ spec:
       {{- include "yugabyte.labels" $root | indent 6 }}
   issuerRef:
     name:  {{ include "yugabyte.tls_cm_issuer" $root | quote }}
-    {{- if $root.Values.tls.certManager.useClusterIssuer }}
+    {{- if $root.Values.tls.certManager.issuerRef.group }}
+    group: {{ $root.Values.tls.certManager.issuerRef.group }}
+    {{- end }}
+    {{- if $root.Values.tls.certManager.issuerRef.kind }}
+    kind: {{ $root.Values.tls.certManager.issuerRef.kind }}
+    {{- else if $root.Values.tls.certManager.useClusterIssuer }}
     kind: ClusterIssuer
     {{- else }}
     kind: Issuer

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -79,6 +79,9 @@ tls:
     clusterIssuer: cluster-ca
     # Name of Issuer to use when useClusterIssuer is false
     issuer: yugabyte-ca
+    issuerRef:
+      group:
+      kind:
     certificates:
       # The lifetime before cert-manager will issue a new certificate.
       # The re-issued certificates will not be automatically reloaded by the service.


### PR DESCRIPTION
My cert-manager CA issuer is different from de default, I need to change group and kind. This PR adds this flexibility and is retrocompatible.