### PR TITLE
[PLAT-11531] Expose terminationGracePeriodSeconds from YBA helm chart

### DIFF
--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -29,6 +29,7 @@ spec:
 {{ toYaml .Values.yugaware.pod.labels | indent 8 }}
 {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.yugaware.pod.terminationGracePeriodSeconds }}
       serviceAccountName: {{ .Values.yugaware.serviceAccount | default .Release.Name }}
       imagePullSecrets:
       - name: {{ .Values.image.pullSecret }}

--- a/stable/yugaware/templates/tests/test.yaml
+++ b/stable/yugaware/templates/tests/test.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  terminationGracePeriodSeconds: 30
   imagePullSecrets:
   - name: {{ .Values.image.pullSecret }}
   containers:

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -83,6 +83,7 @@ yugaware:
   pod:
     annotations: {}
     labels: {}
+    terminationGracePeriodSeconds: 30
   health:
     username: ""
     password: ""


### PR DESCRIPTION
This is so YBM can increase the value to help cleanup coordinated shutdowns of YBA