### PR TITLE
inherit tolerations and nodeSelector from tserver

### DIFF
--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -24,6 +24,12 @@ spec:
         chart: "{{ .Chart.Name }}"
         component: "{{ .Values.Component }}"
     spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tserver.tolerations }}
+      tolerations: {{ toYaml .Values.tserver.tolerations | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: setup-credentials


### PR DESCRIPTION
resolves #178 

per discussion in issue, inherit tolerations from tserver and nodeSelector from root.

test output:
```
# Source: yugabyte/templates/hooks/setup-credentials-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: release-name-yugabyte-setup-credentials
  namespace: "default"
  labels:
    app: "setup-credentials"
    release: "release-name"
    chart: "yugabyte"
    component: "yugabytedb"
  annotations:
    "helm.sh/hook": post-install
    "helm.sh/hook-weight": "0"
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  backoffLimit: 2
  template:
    metadata:
      name: "setup-credentials"
      labels:
        app: "setup-credentials"
        release: "release-name"
        chart: "yugabyte"
        component: "yugabytedb"
    spec:
      nodeSelector:
        diskType: ssd
      tolerations:
        - effect: NoSchedule
          key: test
          operator: Equal
          value: test
      restartPolicy: Never
      containers:
      - name: setup-credentials
        image: "yugabytedb/yugabyte:2.19.3.0-b140"
        env:
        - name: YSQL_USER
          value: "test"
        - name: YSQL_PASSWORD
          value: "test"
        - name: YSQL_DB
          value: "test"
        command:
        - 'bash'
        - '/home/yugabyte/bin/setup-credentials/setup-credentials.sh'
        volumeMounts:
        - name: setup-credentials-script
          mountPath: "/home/yugabyte/bin/setup-credentials"
      volumes:
      - name: setup-credentials-script
        configMap:
          name: release-name-yugabyte-setup-credentials-script

```