### PR TITLE
[#20344] yugabyted: yugabyted UI support for K8s helm chart

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -503,7 +503,9 @@ spec:
             {{- end }}
               --rpc_bind_addresses={{ $rpcAddr }} \
               --server_broadcast_addresses={{ $broadcastAddr }} \
-              --webserver_interface={{ $webserverAddr }}
+              --webserver_interface={{ $webserverAddr }} \
+              --master_enable_metrics_snapshotter={{ $root.Values.metricsSnapshotter.enabled }} \
+              --metrics_snapshotter_tserver_metrics_whitelist={{ join "," $root.Values.metricsSnapshotter.whitelist }}
           {{- else }}
             {{- $cqlAddr := include "yugabyte.cql_proxy_bind_address" $serviceValues -}}
             {{- $cqlPort := index $service.ports "tcp-yql-port" -}}
@@ -565,7 +567,10 @@ spec:
             {{- else }}
               --enable_ysql=false \
             {{- end }}
-              --cql_proxy_bind_address={{ $cqlAddr }}
+              --cql_proxy_bind_address={{ $cqlAddr }} \
+              --tserver_enable_metrics_snapshotter={{ $root.Values.metricsSnapshotter.enabled }} \
+              --metrics_snapshotter_interval_ms={{ $root.Values.metricsSnapshotter.interval }} \
+              --metrics_snapshotter_tserver_metrics_whitelist={{ join "," $root.Values.metricsSnapshotter.whitelist }}
           {{- end }}
         ports:
           {{- range $label, $port := .ports }}
@@ -632,7 +637,47 @@ spec:
         resources: {{ toYaml $root.Values.ybCleanup.resources | nindent 10 }}
         {{- end }}
       {{- end }}
-
+      {{- if $root.Values.yugabytedUi.enabled }}
+      - name: yugabyted-ui
+        image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+          - "/sbin/tini"
+          - "--"
+        args:
+          - "/bin/bash"
+          - "-c"
+          - |
+            /home/yugabyte/bin/yugabyted-ui \
+            {{- $rpcAddr := include "yugabyte.rpc_bind_address" $serviceValues }}
+              -database_host={{ $rpcAddr }} \
+            {{- $webserverAddr := include "yugabyte.webserver_interface" $serviceValues }}
+              -bind_address={{ $webserverAddr }} \
+            {{- $masterPort := "7000" }}
+            {{- $tserverPort := "9000" }}
+            {{- range $root.Values.Services -}}
+              {{- if eq .name "yb-masters" -}}
+                {{- $masterPort = index .ports "http-ui" -}}
+              {{- else if eq .name "yb-tservers" -}}
+                {{- $tserverPort = index .ports "http-ui" -}}
+              {{- end -}}
+            {{- end }}
+              -master_ui_port={{ $masterPort }} \
+              -tserver_ui_port={{ $tserverPort }} \
+            {{- if $root.Values.tls.enabled }}
+              -secure={{ $root.Values.tls.enabled }} \
+              -database_password={{ $root.Values.authCredentials.ycql.password }} \
+            {{- end }}
+      {{- end }}
       {{- if and (eq .name "yb-tservers") ($root.Values.ybc.enabled) }}
       - name: yb-controller
         image: "{{ $root.Values.Image.repository }}:{{ $root.Values.Image.tag }}"

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -8,7 +8,7 @@ nameOverride: ""
 
 Image:
   repository: "yugabytedb/yugabyte"
-  tag: 2.19.3.0-b140
+  tag: latest
   pullPolicy: IfNotPresent
   pullSecretName: ""
 
@@ -115,6 +115,22 @@ gflags:
   tserver: {}
 #   use_cassandra_authentication: false
 
+yugabytedUi:
+  enabled: true
+
+metricsSnapshotter:
+  enabled: true
+  # time between each metric snapshot in ms
+  interval: 11000
+  whitelist:
+    - handler_latency_yb_tserver_TabletServerService_Read_count
+    - handler_latency_yb_tserver_TabletServerService_Write_count
+    - handler_latency_yb_tserver_TabletServerService_Read_sum
+    - handler_latency_yb_tserver_TabletServerService_Write_sum
+    - disk_usage
+    - cpu_usage
+    - node_up
+
 PodManagementPolicy: Parallel
 
 enableLoadBalancer: true
@@ -177,6 +193,7 @@ Services:
     ports:
       http-ui: "7000"
       tcp-rpc-port: "7100"
+      yugabyted-ui: "15433"
 
   - name: "yb-tservers"
     label: "yb-tserver"
@@ -191,6 +208,7 @@ Services:
       http-yedis-met: "11000"
       http-ysql-met: "13000"
       grpc-ybc-port: "18018"
+      yugabyted-ui: "15433"
 
 
 ## Should be set to true only if Istio is being used. This also adds
@@ -504,6 +522,7 @@ helm2Legacy: false
 ip_version_support: "v4_only" # v4_only, v6_only are the only supported values at the moment
 
 # For more https://docs.yugabyte.com/latest/reference/configuration/yugabyted/#environment-variables
+# Note: for yugabyted-ui to work properly with credentials, ysql/ycql passwords must be the same
 authCredentials:
   ysql:
     user: ""


### PR DESCRIPTION
Changes to the yugabyte helm chart to support yugabyted-ui:
- Enables yugabyted-ui by default on port 15433 for each tserver and master.
- Metrics snapshotter enabled by default since yugabyted-ui uses it to display metrics.
- Works with and without tls enabled (`tls.enabled=true` flag)
- Can be disabled with `yugabytedUi.enabled=false` flag)

Sample command:
```
helm install yb-demo /home/centos/code/charts-fork/stable/yugabyte \
--set resource.master.requests.cpu=0.5,resource.master.requests.memory=0.5Gi,\
resource.tserver.requests.cpu=0.5,resource.tserver.requests.memory=0.5Gi,\
replicas.master=3,replicas.tserver=3,tls.enabled=true --namespace yb-demo
```

**NOTE**: Do not merge until `tag` in `stable/yugabyte/values.yaml` has been updated to the correct value, as well as `version` and `appVersion` in `stable/yugabyte/Chart.yaml`.
