### PR TITLE
Use HTTPS to scrape platform metrics when tls is enabled.

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -583,17 +583,8 @@ data:
       {{- end }}
       {{- end }}
  
-      {{- if not .Values.tls.enabled }}
-
-      - job_name: 'platform'
-        metrics_path: "/api/v1/prometheus_metrics"
-        static_configs:
-          - targets: [
-            '{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9000'
-          ]
-
-      {{- else }}
-
+      {{- if and (not .Values.useNginxProxy) (.Values.tls.enabled) }}
+      
       - job_name: 'platform'
         metrics_path: "/api/v1/prometheus_metrics"
         scheme: https
@@ -602,6 +593,15 @@ data:
         static_configs:
           - targets: [
             '{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9443'
+          ]
+
+      {{- else }}
+
+      - job_name: 'platform'
+        metrics_path: "/api/v1/prometheus_metrics"
+        static_configs:
+          - targets: [
+            '{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9000'
           ]
 
       {{- end }}

--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -582,6 +582,8 @@ data:
 
       {{- end }}
       {{- end }}
+ 
+      {{- if not .Values.tls.enabled }}
 
       - job_name: 'platform'
         metrics_path: "/api/v1/prometheus_metrics"
@@ -590,7 +592,24 @@ data:
             '{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9000'
           ]
 
+      {{- else }}
+
+      - job_name: 'platform'
+        metrics_path: "/api/v1/prometheus_metrics"
+        scheme: https
+        tls_config:
+          insecure_skip_verify: true
+        static_configs:
+          - targets: [
+            '{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}:9443'
+          ]
+
+      {{- end }}
+
+
+
       {{- if .Values.prometheus.selfMonitor }}
+      
       - job_name: 'prometheus'
         metrics_path: "/metrics"
         static_configs:


### PR DESCRIPTION
PLAT-12210 When TLS is enabled for YBA Yugaware we should use https to scrape the platform metrics endpoint.

Added some empty line just for rendering.

Tested on EKS



Only unknow is Nginx, not sure we should still support it or not and what need to be done to support it.