### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -31,7 +31,7 @@ jobs:
           exit 1
         fi
         echo "Extracted the version number '${version_number}'."
-        echo "::set-output name=yb_version::${version_number}"
+        echo "yb_version=${version_number}" >> "$GITHUB_OUTPUT"
     - name: "Switch to correct branch"
       id: switch-branch
       run: |
@@ -49,7 +49,7 @@ jobs:
           git checkout -b ${branch_name} origin/master
         fi
         echo "Extracted the branch: '${branch_name}'"
-        echo "::set-output name=yb_branch::${branch_name}"
+        echo "yb_branch=${branch_name}" >> "$GITHUB_OUTPUT"
     - name: "Check python version and install dependencies"
       run: |
         python3 --version


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter