### PR TITLE
Set correct secret name for yugabyte-tls-client-cert

### DIFF
--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -74,7 +74,7 @@ spec:
       {{- if .Values.tls.enabled }}
       - name: yugabyte-tls-client-cert
         secret:
-          secretName: {{ $root.Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" $root)) }}
+          secretName: {{ .Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" . )) }}
           defaultMode: 256
       {{- end }}
 {{- end }}

--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -74,7 +74,7 @@ spec:
       {{- if .Values.tls.enabled }}
       - name: yugabyte-tls-client-cert
         secret:
-          secretName: yugabyte-tls-client-cert
+          secretName: {{ $root.Values.oldNamingStyle | ternary "yugabyte-tls-client-cert" (printf "%s-client-tls" (include "yugabyte.fullname" $root)) }}
           defaultMode: 256
       {{- end }}
 {{- end }}


### PR DESCRIPTION
If the release name is e.g. "yugabyte-staging", the setup credentials job will never become ready, waiting for a secret with the name "yugabyte-tls-client-cert". 

While the actual secret is named "yugabyte-staging-tls-client-cert".

Even when using a default deployment it expects `yugabyte-tls-client-cert` the secret name should be `yugabyte-client-tls`.

