### PR TITLE
Fix hostname in credentials configmap

### DIFF
--- a/stable/yugabyte/templates/setup-credentials-configmap.yaml
+++ b/stable/yugabyte/templates/setup-credentials-configmap.yaml
@@ -37,12 +37,12 @@ data:
     {{- end }}
 
     prefix_ysql_cmd=(
-      /home/yugabyte/bin/ysqlsh -h yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+      /home/yugabyte/bin/ysqlsh -h {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
       -p "$YSQL_PORT"
     )
 
     prefix_ycql_cmd=(
-      /home/yugabyte/bin/ycqlsh yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+      /home/yugabyte/bin/ycqlsh {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
       "$YCQL_PORT"
     )
 
@@ -76,7 +76,7 @@ data:
       declare -a ysql_cmd
       export PGPASSWORD="$2"
       ysql_cmd=(
-        /home/yugabyte/bin/ysqlsh -h yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+        /home/yugabyte/bin/ysqlsh -h {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
         -p "$3"
         -U "$1"
         -c "\\conninfo"

--- a/stable/yugabyte/templates/setup-credentials-configmap.yaml
+++ b/stable/yugabyte/templates/setup-credentials-configmap.yaml
@@ -35,7 +35,8 @@ data:
         readonly YCQL_PORT={{ index $service.ports "tcp-yql-port" }}
       {{- end }}
     {{- end }}
-
+{{- $serviceName := .Values.oldNamingStyle | ternary "yb-tservers" (printf "%s-yb-tservers" (include "yugabyte.fullname" . )) }}
+{{- $tserverFQDN := printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.domainName }}
     prefix_ysql_cmd=(
       /home/yugabyte/bin/ysqlsh -h {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
       -p "$YSQL_PORT"

--- a/stable/yugabyte/templates/setup-credentials-configmap.yaml
+++ b/stable/yugabyte/templates/setup-credentials-configmap.yaml
@@ -38,12 +38,12 @@ data:
 {{- $serviceName := .Values.oldNamingStyle | ternary "yb-tservers" (printf "%s-yb-tservers" (include "yugabyte.fullname" . )) }}
 {{- $tserverFQDN := printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.domainName }}
     prefix_ysql_cmd=(
-      /home/yugabyte/bin/ysqlsh -h {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+      /home/yugabyte/bin/ysqlsh -h {{ $tserverFQDN }}
       -p "$YSQL_PORT"
     )
 
     prefix_ycql_cmd=(
-      /home/yugabyte/bin/ycqlsh {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+      /home/yugabyte/bin/ycqlsh {{ $tserverFQDN }}
       "$YCQL_PORT"
     )
 
@@ -77,7 +77,7 @@ data:
       declare -a ysql_cmd
       export PGPASSWORD="$2"
       ysql_cmd=(
-        /home/yugabyte/bin/ysqlsh -h {{ .Release.Name }}-yb-tservers.{{ .Release.Namespace }}.svc.{{ .Values.domainName }}
+        /home/yugabyte/bin/ysqlsh -h {{ $tserverFQDN }}
         -p "$3"
         -U "$1"
         -c "\\conninfo"

--- a/stable/yugabyte/templates/setup-credentials-configmap.yaml
+++ b/stable/yugabyte/templates/setup-credentials-configmap.yaml
@@ -35,8 +35,10 @@ data:
         readonly YCQL_PORT={{ index $service.ports "tcp-yql-port" }}
       {{- end }}
     {{- end }}
-{{- $serviceName := .Values.oldNamingStyle | ternary "yb-tservers" (printf "%s-yb-tservers" (include "yugabyte.fullname" . )) }}
-{{- $tserverFQDN := printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.domainName }}
+
+    {{- $serviceName := .Values.oldNamingStyle | ternary "yb-tservers" (printf "%s-yb-tservers" (include "yugabyte.fullname" . )) }}
+    {{- $tserverFQDN := printf "%s.%s.svc.%s" $serviceName .Release.Namespace .Values.domainName }}
+
     prefix_ysql_cmd=(
       /home/yugabyte/bin/ysqlsh -h {{ $tserverFQDN }}
       -p "$YSQL_PORT"


### PR DESCRIPTION
The actual services created have the `Release.Name` as a prefix.

Without this, I see the following error:

```
yugabyte-setup-credentials-2pnbw setup-credentials Waiting for YugabyteDB to start.
yugabyte-setup-credentials-2pnbw setup-credentials /home/yugabyte/bin/ysqlsh -h yb-tservers.product-staging.svc.cluster.local -p 5433 -U yugabyte -c \conninfo sslmode=require

yugabyte-setup-credentials-2pnbw setup-credentials ysqlsh: could not translate host name "yb-tservers.product-staging.svc.cluster.local" to address: Name or service not known
```