### PR TITLE
Add startup and liveness probes to yugaware container

### DIFF
--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -538,6 +538,21 @@ spec:
           ports:
             - containerPort: 9000
               name: yugaware
+          startupProbe: # startup could take from ~30 seconds to ~5 minutes
+            failureThreshold: 60
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            httpGet:
+                path: /api/app_version
+                port: yugaware
+          livenessProbe: # less frequent but more sensitive than startupProbe
+            failureThreshold: 3
+            periodSeconds: 30
+            timeoutSeconds: 10
+            httpGet:
+                path: /api/app_version
+                port: yugaware
           volumeMounts:
           - name: yugaware-config
             mountPath: /data

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -538,21 +538,23 @@ spec:
           ports:
             - containerPort: 9000
               name: yugaware
-          startupProbe: # startup could take from ~30 seconds to ~5 minutes
-            failureThreshold: 60
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            timeoutSeconds: 5
+          {{- if .Values.yugaware.pod.probes.enabled }}
+          startupProbe:
+            failureThreshold: {{ div .Values.yugaware.pod.probes.startupTimeSec.max (div .Values.yugaware.pod.probes.startupTimeSec.min 2) }}
+            initialDelaySeconds: {{ .Values.yugaware.pod.probes.startupTimeSec.min }}
+            periodSeconds: {{ div .Values.yugaware.pod.probes.startupTimeSec.min 2 }}
+            timeoutSeconds: {{ div .Values.yugaware.pod.probes.startupTimeSec.min 4 }}
             httpGet:
                 path: /api/app_version
                 port: yugaware
-          livenessProbe: # less frequent but more sensitive than startupProbe
-            failureThreshold: 3
-            periodSeconds: 30
-            timeoutSeconds: 10
+          livenessProbe:
+            failureThreshold: {{ .Values.yugaware.pod.probes.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.yugaware.pod.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ div .Values.yugaware.pod.probes.livenessProbe.periodSeconds 2 }}
             httpGet:
                 path: /api/app_version
                 port: yugaware
+          {{- end }}
           volumeMounts:
           - name: yugaware-config
             mountPath: /data

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -91,7 +91,7 @@ yugaware:
         max: 600 # maximum expected time for yugaware to start, k8s will restart pod on timeout
       livenessProbe:
         periodSeconds: 30 # query period
-        failureThreshold: 3 # number of failed checks to restart pod
+        failureThreshold: 10 # number of failed checks to restart pod
   health:
     username: ""
     password: ""

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -84,6 +84,14 @@ yugaware:
     annotations: {}
     labels: {}
     terminationGracePeriodSeconds: 30
+    probes: # HTTP healthcheck probes configuration
+      enabled: false # add or not livenessProbe and startupProbe to the container
+      startupTimeSec:
+        min: 20 # minimum expected time for yugaware to start
+        max: 600 # maximum expected time for yugaware to start, k8s will restart pod on timeout
+      livenessProbe:
+        periodSeconds: 30 # query period
+        failureThreshold: 3 # number of failed checks to restart pod
   health:
     username: ""
     password: ""


### PR DESCRIPTION
PR adds 2 health probes for yugaware container within a pod.
Startup probe has low `initialDelaySeconds`, what allows the pod to be quicky available for small deployments. High `failureThreshold` allows to tolerate long-running DB migrations and other startup operations. 10s `periodSeconds` ensures a quick reaction on container state change.
Liveness probe checks container less frequently, but tolerates only 3 failed probes.