### PR TITLE
[DEVOPS-2986] helm charts: Separate version updates for YBDB/YBA

### DIFF
--- a/.ci/find_docker_tag.py
+++ b/.ci/find_docker_tag.py
@@ -5,7 +5,8 @@ from re import match
 from requests import request
 from sys import exit
 
-DOCKER_TAGS_URL = "https://registry.hub.docker.com/v2/repositories/yugabytedb/yugabyte/tags"
+DOCKER_TAGS_URL = "https://registry.hub.docker.com/v2/repositories/" + \
+                  "yugabytedb/yugabyte/tags?page_size=100"
 
 
 def main(release):

--- a/.ci/update_version.sh
+++ b/.ci/update_version.sh
@@ -2,27 +2,8 @@
 
 set -o errexit -o pipefail
 
-# version_gt compares the given two versions.
-# It returns 0 exit code if the version1 is greater than version2.
-# https://web.archive.org/web/20191003081436/http://ask.xmodulo.com/compare-two-version-numbers.html
-function version_gt() {
-  test "$(echo -e "$1\n$2" | sort -V | head -n 1)" != "$1"
-}
-
-function is_semver_compatible() {
-  local version="$1"
-  local number_of_dots
-  number_of_dots=$(grep -o '\.' <<< "${version}" | wc -l)
-
-  if [[ ${number_of_dots} -gt 2 ]]; then
-    # format: 2.18.0.1
-    return 1
-  else
-    # format: 2.18.0+1
-    return 0
-  fi
-}
-
+# This script is deprecated, replaced by update_ybdb_version.sh and update_yba_version.sh
+# Retained here for compatibility until packaging and release workflows switch over.
 
 if [[ $# < 1 || $# > 2 ]]; then
   echo "Incorrect number of arguments. Usage: ${0%*/} <version> [<docker-tag>]" 1>&2
@@ -33,13 +14,6 @@ fi
 input_release_version="$1"
 release_version="${input_release_version//+/.}"
 docker_image_tag="$2"
-
-# appVersion mentioned in Charts.yaml
-current_version="$(grep -r "^appVersion" "stable/yugabyte/Chart.yaml" | awk '{ print $2 }')"
-if ! version_gt "${release_version}" "${current_version%-b*}" ; then
-  echo "Release version is either older or equal to the current version: '${release_version}' <= '${current_version%-b*}'" 1>&2
-  exit 1
-fi
 
 if [[ -z "$docker_image_tag" ]]; then
   # Find Docker image tag respective to YugabyteDB release version
@@ -53,34 +27,5 @@ if [[ -z "$docker_image_tag" ]]; then
   fi
 fi
 
-# Following parameters will be updated in the below-mentioned files:
-#  1. ./stable/yugabyte/Chart.yaml	 -   version, appVersion
-#  2. ./stable/yugabyte/values.yaml	 -   tag
-#  3. ./stable/yugaware/Chart.yaml	 -   version, appVersion
-#  4. ./stable/yugaware/values.yaml	 -   tag
-#  5. ./stable/yugabyte/app-readme.md	 -   *.*.*.*-b*
-
-files_to_update_version=("stable/yugabyte/Chart.yaml" "stable/yugaware/Chart.yaml")
-files_to_update_tag=("stable/yugabyte/values.yaml" "stable/yugaware/values.yaml")
-chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"
-
-if is_semver_compatible "${input_release_version}"; then
-  chart_release_version="${input_release_version}"
-fi
-
-# Update appVersion and version in Chart.yaml
-for file in "${files_to_update_version[@]}"; do
-  echo "Updating file: '${file}' with version: '${chart_release_version}', appVersion: '${docker_image_tag}'"
-  sed -i "s/^version: .*/version: ${chart_release_version}/g" "${file}"
-  sed -i "s/^appVersion: .*/appVersion: ${docker_image_tag}/g" "${file}"
-done
-
-# Update tag in values.yaml
-for file in "${files_to_update_tag[@]}"; do
-  echo "Updating file: '${file}' with tag: '${docker_image_tag}'"
-  sed -i "s/^  tag: .*/  tag: ${docker_image_tag}/g" "${file}"
-done
-
-# Update version number in stable/yugabyte/app-readme.md
-echo "Updating file: 'stable/yugabyte/app-readme.md' with version: '${docker_image_tag}'"
-sed -i "s/[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+-b[0-9]\+/${docker_image_tag}/g" "stable/yugabyte/app-readme.md"
+.ci/update_ybdb_version.sh "${release_version}" "${docker_image_tag}"
+.ci/update_yba_version.sh "${release_version}" "${docker_image_tag}"

--- a/.ci/update_yba_version.sh
+++ b/.ci/update_yba_version.sh
@@ -38,7 +38,7 @@ current_version="$(grep -r "^appVersion" "stable/yugaware/Chart.yaml" | awk '{ p
 if ! version_gt "${release_version}" "${current_version%-b*}" ; then
   echo "Release version is either older or equal to the current version: " \
     "'${release_version}' <= '${current_version%-b*}'" 1>&2
-  exit 1
+  exit 3
 fi
 
 chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"

--- a/.ci/update_yba_version.sh
+++ b/.ci/update_yba_version.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# version_gt compares the given two versions.
+# It returns 0 exit code if the version1 is greater than version2.
+# https://web.archive.org/web/20191003081436/http://ask.xmodulo.com/compare-two-version-numbers.html
+function version_gt() {
+  test "$(echo -e "$1\n$2" | sort -V | head -n 1)" != "$1"
+}
+
+function is_semver_compatible() {
+  local version="$1"
+  local number_of_dots
+  number_of_dots=$(grep -o '\.' <<< "${version}" | wc -l)
+
+  if [[ ${number_of_dots} -gt 2 ]]; then
+    # format: 2.18.0.1
+    return 1
+  else
+    # format: 2.18.0+1
+    return 0
+  fi
+}
+
+
+if [[ $# != 2 ]]; then
+  echo "Incorrect number of arguments. Usage: ${0%*/} <version> <docker-tag>" 1>&2
+  echo "Terminating the script execution." 1>&2
+  exit 1
+fi
+
+release_version="$1"
+docker_image_tag="$2"
+
+# appVersion mentioned in Charts.yaml
+current_version="$(grep -r "^appVersion" "stable/yugaware/Chart.yaml" | awk '{ print $2 }')"
+if ! version_gt "${release_version}" "${current_version%-b*}" ; then
+  echo "Release version is either older or equal to the current version: " \
+    "'${release_version}' <= '${current_version%-b*}'" 1>&2
+  exit 1
+fi
+
+chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"
+
+if is_semver_compatible "${input_release_version}"; then
+  chart_release_version="${input_release_version}"
+fi
+
+# Update appVersion and version in Chart.yaml
+echo "Updating file: 'stable/yugaware/Chart.yaml' with version: " \
+  "'${chart_release_version}', appVersion: '${docker_image_tag}'"
+sed -i "s/^version: .*/version: ${chart_release_version}/g" "stable/yugaware/Chart.yaml"
+sed -i "s/^appVersion: .*/appVersion: ${docker_image_tag}/g" "stable/yugaware/Chart.yaml"
+
+# Update tag in values.yaml
+echo "Updating file: 'stable/yugaware/values.yaml' with tag: '${docker_image_tag}'"
+sed -i "s/^  tag: .*/  tag: ${docker_image_tag}/g" "stable/yugaware/values.yaml"

--- a/.ci/update_yba_version.sh
+++ b/.ci/update_yba_version.sh
@@ -43,8 +43,8 @@ fi
 
 chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"
 
-if is_semver_compatible "${input_release_version}"; then
-  chart_release_version="${input_release_version}"
+if is_semver_compatible "${release_version}"; then
+  chart_release_version="${release_version}"
 fi
 
 # Update appVersion and version in Chart.yaml

--- a/.ci/update_ybdb_version.sh
+++ b/.ci/update_ybdb_version.sh
@@ -38,7 +38,7 @@ current_version="$(grep -r "^appVersion" "stable/yugabyte/Chart.yaml" | awk '{ p
 if ! version_gt "${release_version}" "${current_version%-b*}" ; then
   echo "Release version is either older or equal to the current version: " \
     "'${release_version}' <= '${current_version%-b*}'" 1>&2
-  exit 1
+  exit 3
 fi
 
 chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"

--- a/.ci/update_ybdb_version.sh
+++ b/.ci/update_ybdb_version.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# version_gt compares the given two versions.
+# It returns 0 exit code if the version1 is greater than version2.
+# https://web.archive.org/web/20191003081436/http://ask.xmodulo.com/compare-two-version-numbers.html
+function version_gt() {
+  test "$(echo -e "$1\n$2" | sort -V | head -n 1)" != "$1"
+}
+
+function is_semver_compatible() {
+  local version="$1"
+  local number_of_dots
+  number_of_dots=$(grep -o '\.' <<< "${version}" | wc -l)
+
+  if [[ ${number_of_dots} -gt 2 ]]; then
+    # format: 2.18.0.1
+    return 1
+  else
+    # format: 2.18.0+1
+    return 0
+  fi
+}
+
+
+if [[ $# != 2 ]]; then
+  echo "Incorrect number of arguments. Usage: ${0%*/} <version> <docker-tag>" 1>&2
+  echo "Terminating the script execution." 1>&2
+  exit 1
+fi
+
+release_version="$1"
+docker_image_tag="$2"
+
+# appVersion mentioned in Charts.yaml
+current_version="$(grep -r "^appVersion" "stable/yugabyte/Chart.yaml" | awk '{ print $2 }')"
+if ! version_gt "${release_version}" "${current_version%-b*}" ; then
+  echo "Release version is either older or equal to the current version: " \
+    "'${release_version}' <= '${current_version%-b*}'" 1>&2
+  exit 1
+fi
+
+chart_release_version="$(echo "${release_version}" | grep -o '[0-9]\+.[0-9]\+.[0-9]\+')"
+
+if is_semver_compatible "${release_version}"; then
+  chart_release_version="${release_version}"
+fi
+
+# Update appVersion and version in Chart.yaml
+echo "Updating file: 'stable/yugabyte/Chart.yaml' with version: '${chart_release_version}'," \
+     "appVersion: '${docker_image_tag}'"
+sed -i "s/^version: .*/version: ${chart_release_version}/g" "stable/yugabyte/Chart.yaml"
+sed -i "s/^appVersion: .*/appVersion: ${docker_image_tag}/g" "stable/yugabyte/Chart.yaml"
+
+# Update tag in values.yaml
+echo "Updating file: 'stable/yugabyte/values.yaml' with tag: '${docker_image_tag}'"
+sed -i "s/^  tag: .*/  tag: ${docker_image_tag}/g" "stable/yugabyte/values.yaml"
+
+# Update version number in stable/yugabyte/app-readme.md
+echo "Updating file: 'stable/yugabyte/app-readme.md' with version: '${docker_image_tag}'"
+sed -i "s/[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+-b[0-9]\+/${docker_image_tag}/g" \
+  "stable/yugabyte/app-readme.md"


### PR DESCRIPTION
Split update_version script into two parts so that it can be called separately for YBDB and YBA.
New scripts added so that workflows can check if script exists and use the new protocol or fallback to the old one for older releases.

The old script is retained for now for compatibility until workflows can migrate.

find_docker script slightly modified to be able to find slightly older releases, even though this script will also not be needed in future workflows.