### PR TITLE
Optionally use secret to set env variables in setup credentials job #194

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,0 +1,24 @@
+name: "Run Unit tests"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  yugabyte-unittests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Install Helm"
+      run: |
+        curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+        chmod 700 get_helm.sh
+        ./get_helm.sh
+    - name: "Install Helm Unittest"
+      run: helm plugin install https://github.com/helm-unittest/helm-unittest.git
+    - name: "Checkout"
+      uses: actions/checkout@v2
+    - name: "Run tests"
+      run: cd stable/yugabyte && pwd && helm unittest -f "tests/test_*.yaml" .
+    

--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.authCredentials.ycql.user .Values.authCredentials.ycql.password .Values.authCredentials.ycql.keyspace .Values.authCredentials.ysql.password .Values.authCredentials.ysql.user .Values.authCredentials.ysql.database }}
+{{- if or .Values.authCredentials.ycql.user .Values.authCredentials.ycql.password .Values.authCredentials.ycql.keyspace .Values.authCredentials.ysql.password .Values.authCredentials.ysql.user .Values.authCredentials.ysql.database .Values.authCredentials.ycql.passwordSecretName .Values.authCredentials.ysql.passwordSecretName .Values.authCredentials.ycql.passwordSecretName .Values.authCredentials.ysql.passwordSecretName .Values.authCredentials.ycql.passwordSecretName .Values.authCredentials.ysql.passwordSecretName}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,9 +39,16 @@ spec:
         - name: YSQL_USER
           value: "{{ .Values.authCredentials.ysql.user }}"
         {{- end }}
-        {{- if .Values.authCredentials.ysql.password }}
+        {{- if or .Values.authCredentials.ysql.password .Values.authCredentials.ysql.passwordSecretName }}
         - name: YSQL_PASSWORD
+          {{- if .Values.authCredentials.ysql.passwordSecretName }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.authCredentials.ysql.passwordSecretName }}
+              key: ysqlPassword
+          {{- else }}
           value: "{{ .Values.authCredentials.ysql.password }}"
+          {{- end -}}
         {{- end }}
         {{- if .Values.authCredentials.ysql.database }}
         - name: YSQL_DB
@@ -51,9 +58,16 @@ spec:
         - name: YCQL_USER
           value: "{{ .Values.authCredentials.ycql.user }}"
         {{- end }}
-        {{- if .Values.authCredentials.ycql.password }}
+        {{- if or (.Values.authCredentials.ycql.password) (.Values.authCredentials.ycql.passwordSecretName) }}
         - name: YCQL_PASSWORD
+          {{- if .Values.authCredentials.ycql.passwordSecretName  }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.authCredentials.ycql.passwordSecretName }}
+              key: ycqlPassword
+          {{- else }}
           value: "{{ .Values.authCredentials.ycql.password }}"
+          {{- end -}}
         {{- end }}
         {{- if .Values.authCredentials.ycql.keyspace }}
         - name: YCQL_KEYSPACE

--- a/stable/yugabyte/tests/README.md
+++ b/stable/yugabyte/tests/README.md
@@ -15,5 +15,5 @@ $ helm plugin install https://github.com/helm-unittest/helm-unittest.git
 ## Run tests
 ```
 $ cd stable/yugabyte
-$ helm unittest -f tests/test_*.yaml .
+$ helm unittest -f "tests/test_*.yaml" .
 ```

--- a/stable/yugabyte/tests/test_affinity_merges.yaml
+++ b/stable/yugabyte/tests/test_affinity_merges.yaml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/quintush/helm-unittest/master/schema/helm-testsuite.json
 suite: nodeAffinity and podAntiAffinity Merge
-templates:
-- service.yaml
 tests:
 - it: Test with AZ
+  template: templates/service.yaml
   values:
   - ./values_affinity_merge.yaml
   set:
@@ -60,7 +59,7 @@ tests:
             operator: In
             values:
             - custom_value_2
-    documentIndex: 2
+    documentIndex: 1
   - isSubset:
       path: spec.template.spec.affinity.podAntiAffinity
       content:
@@ -82,7 +81,7 @@ tests:
                 operator: In
                 values:
                 - paa_value
-    documentIndex: 2
+    documentIndex: 1
   - isSubset:
       path: spec.template.spec.affinity.nodeAffinity
       content:
@@ -100,7 +99,7 @@ tests:
               - test_az
         preferredDuringSchedulingIgnoredDuringExecution:
           random_key: random_value
-    documentIndex: 6
+    documentIndex: 4
   - isSubset:
       path: spec.template.spec.affinity.podAntiAffinity
       content:
@@ -116,8 +115,9 @@ tests:
             topologyKey: kubernetes.io/hostname                
         requiredDuringSchedulingIgnoredDuringExecution:
           random_key2: random_value2
-    documentIndex: 6
+    documentIndex: 4
 - it: Test without AZ
+  template: templates/service.yaml
   values:
   - ./values_affinity_merge.yaml
   set:
@@ -143,7 +143,7 @@ tests:
             operator: In
             values:
             - custom_value_2        
-    documentIndex: 2
+    documentIndex: 1
   - isSubset:
       path: spec.template.spec.affinity.podAntiAffinity
       content:
@@ -165,13 +165,13 @@ tests:
                 operator: In
                 values:
                 - paa_value
-    documentIndex: 2
+    documentIndex: 1
   - isSubset:
       path: spec.template.spec.affinity.nodeAffinity
       content:
         preferredDuringSchedulingIgnoredDuringExecution:
           random_key: random_value
-    documentIndex: 6
+    documentIndex: 4
   - isSubset:
       path: spec.template.spec.affinity.podAntiAffinity
       content:
@@ -187,5 +187,5 @@ tests:
             topologyKey: kubernetes.io/hostname                
         requiredDuringSchedulingIgnoredDuringExecution:
           random_key2: random_value2
-    documentIndex: 6  
+    documentIndex: 4  
 

--- a/stable/yugabyte/tests/test_setup_credentials.yaml
+++ b/stable/yugabyte/tests/test_setup_credentials.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/quintush/helm-unittest/master/schema/helm-testsuite.json
+suite: setup-credentials
+templates:
+- hooks/setup-credentials-job.yaml
+tests:
+- it: YSQL password
+  set:
+    authCredentials:
+      ysql:
+        password: ysql_password
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: YSQL_PASSWORD
+  - equal:
+      path: spec.template.spec.containers[0].env[0].value
+      value: ysql_password
+- it: YSQL password secret
+  set:
+    authCredentials:
+      ysql:
+        passwordSecretName: ysql_password_secret
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: YSQL_PASSWORD
+  - equal:
+      path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+      value: ysql_password_secret
+- it: YCQL password
+  set:
+    authCredentials:
+      ycql:
+        password: ycql_password
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: YCQL_PASSWORD
+  - equal:
+      path: spec.template.spec.containers[0].env[0].value
+      value: ycql_password
+- it: YCQL password secret
+  set:
+    authCredentials:
+      ycql:
+        passwordSecretName: ycql_password_secret
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[0].env[0].name
+      value: YCQL_PASSWORD
+  - equal:
+      path: spec.template.spec.containers[0].env[0].valueFrom.secretKeyRef.name
+      value: ycql_password_secret

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -721,10 +721,14 @@ authCredentials:
     user: ""
     password: ""
     database: ""
+    # Must contain the key ysqlPassword
+    passwordSecretName: ""
   ycql:
     user: ""
     password: ""
     keyspace: ""
+    # Must contain the key ycqlPassword
+    passwordSecretName: ""
 
 oldNamingStyle: true
 


### PR DESCRIPTION
Allow using secrets to setup ysql/ycql passwords. In addition, created some unit tests to validate the output, and unit tests will now run as part of pull requests