### PR TITLE
Add resources configuration on yugabyted-ui container

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -629,6 +629,9 @@ spec:
             trap - TERM INT;
             done \
             {{- end }}
+        {{- if $root.Values.yugabytedUi.resources }}
+        resources: {{ toYaml $root.Values.yugabytedUi.resources | nindent 10 }}
+        {{- end }}
       {{- end }}
 
       {{- if and (eq .name "yb-tservers") ($root.Values.ybc.enabled) }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -156,6 +156,15 @@ yugabytedUi:
       - disk_usage
       - cpu_usage
       - node_up
+  ## https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container
+  ## Use the above link to learn more about Kubernetes resources configuration.
+  # resources:
+  #   requests:
+  #     cpu: "1"
+  #     memory: 1Gi
+  #   limits:
+  #     cpu: "1"
+  #     memory: 1Gi
 
 PodManagementPolicy: Parallel
 


### PR DESCRIPTION
This pull request aims to add configuration capabilities regarding resource requests and limits on ``yugabyted-ui`` container.

This configuration capability is mandatory in Kubernetes clusters with resource quotas enforcing and no default resource request/limit configured.
On this kind of clusters master and t-server pods won't be scheduled without this capability.

The changes mirror what is already done on the ``yb-controller`` container configuration.
resource configuration stays commented by default to preserve current behavior.