### PR TITLE
add imagepullsecret to yugabyte-setup-credentials job

### DIFF
--- a/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
+++ b/stable/yugabyte/templates/hooks/setup-credentials-job.yaml
@@ -24,6 +24,10 @@ spec:
         chart: "{{ .Chart.Name }}"
         component: "{{ .Values.Component }}"
     spec:
+      {{- if Values.Image.pullSecretName }}
+      imagePullSecrets:
+      - name: {{ Values.Image.pullSecretName }}
+      {{ end }}
       {{- if .Values.nodeSelector }}
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
* add imagepullsecret to yugabyte-setup-credentials job
* needed if you need to pull images through an own docker registry