### PR TITLE
Add 'provided' flag for tls certificates

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -1,6 +1,6 @@
 {{- $root := . -}}
 ---
-{{- if and (eq $root.Values.tls.enabled true) (eq $root.Values.tls.certManager.enabled false) }}
+{{- if and (eq $root.Values.tls.enabled true) (eq $root.Values.tls.certManager.enabled false) (eq $root.Values.tls.provided false) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -32,7 +32,7 @@ data:
 {{- $replicas := (eq .name "yb-masters") | ternary $root.Values.replicas.master $root.Values.replicas.tserver -}}
 
 {{- if gt (int ($replicas)) 0 }}
-{{- if and (eq $root.Values.tls.enabled true) (eq $root.Values.tls.certManager.enabled false) }}
+{{- if and (eq $root.Values.tls.enabled true) (eq $root.Values.tls.certManager.enabled false) (eq $root.Values.tls.provided false) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -76,8 +76,10 @@ tls:
   clientToServer: true
   # Set to false to disallow any service with unencrypted communication from joining this cluster
   insecure: false
-  # Set to true to disable any secrets handling. You shall set the secrets with expected name and values (check secrets at the beginning of templates/service.yaml)
-  # If enabled, rootCA, nodeCert and clientCert are ignored
+  # Set to true to disable automatic secrets management.
+  # You must manually create the Kubernetes secrets with the expected names and values
+  # (see the beginning of templates/service.yaml for details).
+  # When enabled, the 'rootCA', 'nodeCert', and 'clientCert' settings are ignored.
   provided: false
 
   # Set enabled to true to use cert-manager instead of providing your own rootCA

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -76,7 +76,7 @@ tls:
   clientToServer: true
   # Set to false to disallow any service with unencrypted communication from joining this cluster
   insecure: false
-  # Set to true to disable any secrets handeling. You shall set the secrets with expected name and values (check secrets at the begining of templates/service.yaml)
+  # Set to true to disable any secrets handling. You shall set the secrets with expected name and values (check secrets at the beginning of templates/service.yaml)
   # If enabled, rootCA, nodeCert and clientCert are ignored
   provided: false
 

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -76,6 +76,10 @@ tls:
   clientToServer: true
   # Set to false to disallow any service with unencrypted communication from joining this cluster
   insecure: false
+  # Set to true to disable any secrets handeling. You shall set the secrets with expected name and values (check secrets at the begining of templates/service.yaml)
+  # If enabled, rootCA, nodeCert and clientCert are ignored
+  provided: false
+
   # Set enabled to true to use cert-manager instead of providing your own rootCA
   certManager:
     enabled: false


### PR DESCRIPTION
This PR add a 'provided' flag in TLS settings.

The goal of this flag is to disable secrets handling from parameters, but let users of the chart manage those secrets as needed/wanted.

It's doesn't change anything by default and it backward compatible :)