### PR TITLE
Add more overrides for rpc bind address and server broadcast address

### DIFF
--- a/stable/yugabyte/templates/master-gflags-secret.yaml
+++ b/stable/yugabyte/templates/master-gflags-secret.yaml
@@ -46,8 +46,8 @@ stringData:
     --num_cpus={{ ceil $root.Values.resource.master.requests.cpu }}
     --max_log_size=256
     --undefok=num_cpus,enable_ysql
-    --rpc_bind_addresses={{ include "yugabyte.rpc_bind_address" $serviceValues }}
-    --server_broadcast_addresses={{ include "yugabyte.server_broadcast_address" $serviceValues }}
+    --rpc_bind_addresses={{ $root.Values.master.rpcBindAddress | default (include "yugabyte.rpc_bind_address" $serviceValues) }}
+    --server_broadcast_addresses={{ $root.Values.master.serverBroadcastAddress | default (include "yugabyte.server_broadcast_address" $serviceValues) }}
     --webserver_interface={{ include "yugabyte.webserver_interface" $serviceValues }}
 {{- range $flag, $override := $root.Values.gflags.master }}
     --{{ $flag }}={{ $override }}

--- a/stable/yugabyte/templates/tserver-gflags-secret.yaml
+++ b/stable/yugabyte/templates/tserver-gflags-secret.yaml
@@ -62,7 +62,7 @@ stringData:
     --undefok=num_cpus,enable_ysql
     --use_node_hostname_for_local_tserver=true
     --cql_proxy_bind_address={{ include "yugabyte.cql_proxy_bind_address" $serviceValues }}
-    --rpc_bind_addresses={{ include "yugabyte.rpc_bind_address" $serviceValues }}
+    --rpc_bind_addresses={{ $root.Values.tserver.rpcBindAddress | default (include "yugabyte.rpc_bind_address" $serviceValues) }}
     --server_broadcast_addresses={{ $root.Values.tserver.serverBroadcastAddress | default (include "yugabyte.server_broadcast_address" $serviceValues) }}
     --webserver_interface={{ include "yugabyte.webserver_interface" $serviceValues }}
 {{- range $flag, $override := $root.Values.gflags.tserver }}

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -457,6 +457,15 @@ master:
   #       fieldPath: status.hostIP
   extraEnv: []
 
+  ## Sets the --server_broadcast_addresses flag on the Master pods, no
+  ## preflight checks are done for this address. You might need to add
+  ## `use_private_ip: cloud` to the gflags.master and gflags.tserver.
+  serverBroadcastAddress: ""
+
+  ## Sets the --rpc_bind_addresses flag on the Master pods, no
+  ## preflight checks are done for this address.
+  rpcBindAddress: ""
+
   # secretEnv variables are used to expose secrets data as env variables in the master pod.
   # TODO Add namespace also to support copying secrets from other namespace.
   # secretEnv:
@@ -632,6 +641,10 @@ tserver:
   ## preflight checks are done for this address. You might need to add
   ## `use_private_ip: cloud` to the gflags.master and gflags.tserver.
   serverBroadcastAddress: ""
+
+  ## Sets the --rpc_bind_addresses flag on the TServer, no
+  ## preflight checks are done for this address.
+  rpcBindAddress: ""
 
   ## Extra volumes
   ## extraVolumesMounts are mandatory for each extraVolumes.


### PR DESCRIPTION
This PR adds optional options to overrides the rpc bind address on master and tserver, and server_broadcast_address on the master (already present on the tserver).

