### PR TITLE
[CLOUDGA-29511] Make promethues container optional

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -86,14 +86,16 @@ data:
       cloud.enabled = {{ .Values.yugaware.cloud.enabled }}
       cloud.requestIdHeader = "{{ .Values.yugaware.cloud.requestIdHeader }}"
       devops.home = /opt/yugabyte/devops
+{{- if .Values.prometheus.enabled }}
       metrics.host = "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}"
       metrics.url = "http://"${yb.metrics.host}":9090/api/v1"
       metrics.management.url = "http://"${yb.metrics.host}":9090/-"
+      swamper.targetPath = /opt/yugabyte/prometheus/targets
+      swamper.rulesPath = /opt/yugabyte/prometheus/rules
+{{- end }}
       storage.path = /opt/yugabyte/yugaware/data
       docker.network = bridge
       seedData = false
-      swamper.targetPath = /opt/yugabyte/prometheus/targets
-      swamper.rulesPath = /opt/yugabyte/prometheus/rules
       security.enable_auth_for_proxy_metrics = {{ .Values.yugaware.enableProxyMetricsAuth }}
       proxy_endpoint_timeout = {{ .Values.yugaware.proxyEndpointTimeoutMs }}
       multiTenant = {{ .Values.yugaware.multiTenant }}
@@ -280,7 +282,7 @@ data:
 
 {{- end }}
 
-{{- if .Values.prometheus.remoteWrite.tls.enabled }}
+{{- if and .Values.prometheus.enabled .Values.prometheus.remoteWrite.tls.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -308,6 +310,7 @@ data:
 {{- end }}
 {{- end}}
 
+{{- if .Values.prometheus.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -664,3 +667,4 @@ data:
 {{ toYaml .Values.prometheus.remoteWrite.config | indent 6}}
     {{- end }}
     scrape_configs: []
+{{- end }}

--- a/stable/yugaware/templates/statefulset.yaml
+++ b/stable/yugaware/templates/statefulset.yaml
@@ -100,6 +100,7 @@ spec:
                     - key: universe_boot_script
                       path: universe-boot-script.sh
             {{- end }}
+        {{- if .Values.prometheus.enabled }}
         - name: prometheus-config
           configMap:
             name: {{ .Release.Name }}-yugaware-prometheus-config
@@ -108,6 +109,7 @@ spec:
                 path: prometheus.yml
               - key: no_scrape.yml
                 path: no_scrape.yml
+        {{- end }}
         {{- if .Values.securityContext.enabled }}
         - name: init-container-script
           configMap:
@@ -195,6 +197,7 @@ spec:
       dnsPolicy: {{ . | quote }}
       {{- end }}
       initContainers:
+        {{- if .Values.prometheus.enabled }}
         - image: {{ include "full_yugaware_image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.initContainers.prometheusConfiguration.resources }}
@@ -235,6 +238,7 @@ spec:
           - name: init-container-script
             mountPath: /init-container
           {{- end }}
+        {{- end }}
         {{- if not .Values.useYugabyteDB }}
         {{- if not (and (.Values.ocpCompatibility.enabled) (eq .Values.image.postgres.registry "registry.redhat.io")) }}
         - image: {{ include "full_image" (dict "containerName" "postgres-upgrade" "root" .) }}
@@ -451,6 +455,7 @@ spec:
                 command: ["/bin/bash", "/ybdb-create-yugware-db/ybdb-create-yugaware-db.sh"]
           {{- end }}
 
+        {{- if .Values.prometheus.enabled }}
         - name: prometheus
           image: {{ include "full_image" (dict "containerName" "prometheus" "root" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -506,6 +511,7 @@ spec:
             - --query.timeout={{ .Values.prometheus.queryTimeout }}
           ports:
             - containerPort: 9090
+        {{- end }}
         - name: yugaware
           image: {{ include "full_yugaware_image" . }}
           {{- if .Values.securityContext.enabled }}
@@ -611,6 +617,7 @@ spec:
           - name: yugaware-storage
             mountPath: /opt/releases/
             subPath: releases
+          {{- if .Values.prometheus.enabled }}
           - name: yugaware-storage
             mountPath: /opt/yugabyte/prometheus/targets
             subPath: swamper_targets
@@ -625,6 +632,7 @@ spec:
           - name: yugaware-storage
             mountPath: /prometheus_data
             subPath: prometheus_data
+          {{- end }}
         {{- if (.Values.tls.enabled) }}
           {{- if .Values.tls.certManager.enabled }}
           - name: {{  .Release.Name }}-yugaware-tls-cert

--- a/stable/yugaware/values.yaml
+++ b/stable/yugaware/values.yaml
@@ -408,6 +408,7 @@ dnsConfig: {}
 
 ## Don't want prometheus to scrape nodes and evaluate alert rules in some cases (for example - cloud).
 prometheus:
+  enabled: true
   ## Setting this to false will disable scraping of TServer and Master
   ## nodes (could be pods or VMs)
   scrapeNodes: true


### PR DESCRIPTION
Different deployments employ distinct metrics collection approaches.
Some utilize Prometheus sidecar containers, while others leverage PodMonitor custom resources or Kubernetes service discovery mechanisms.
So we make the Prometheus container optional.
