### PR TITLE
fix: use "$root" instead of "$"

### DIFF
--- a/stable/yugabyte/templates/multicluster/service-per-pod.yaml
+++ b/stable/yugabyte/templates/multicluster/service-per-pod.yaml
@@ -1,8 +1,9 @@
-{{- if .Values.multicluster.createServicePerPod }}
-{{- range $server := .Values.Services }}
-{{- range $replicaNum := until (int (ternary $.Values.replicas.master $.Values.replicas.tserver (eq $server.name "yb-masters"))) }}
-{{- $appLabelArgs := dict "label" $server.label "root" $ -}}
-{{- $podName := $.Values.oldNamingStyle | ternary $server.label (printf "%s-%s" (include "yugabyte.fullname" $) $server.label) -}}
+{{- $root := . -}}
+{{- if $root.Values.multicluster.createServicePerPod }}
+{{- range $server := $root.Values.Services }}
+{{- range $replicaNum := until (int (ternary $root.Values.replicas.master $root.Values.replicas.tserver (eq $server.name "yb-masters"))) }}
+{{- $appLabelArgs := dict "label" $server.label "root" $root -}}
+{{- $podName := $root.Values.oldNamingStyle | ternary $server.label (printf "%s-%s" (include "yugabyte.fullname" $root) $server.label) -}}
 {{- $podName := printf "%s-%d" $podName $replicaNum -}}
 apiVersion: v1
 kind: Service
@@ -10,13 +11,13 @@ metadata:
   name: {{ $podName | quote }}
   labels:
     {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
-    {{- include "yugabyte.labels" $ | indent 4 }}
+    {{- include "yugabyte.labels" $root | indent 4 }}
     service-type: "non-endpoint"
 spec:
   ports:
     {{- range $label, $port := $server.ports }}
     {{- if or (eq $label "grpc-ybc-port") (eq $label "tcp-ybc-port")}}
-    {{- if $.Values.ybc.enabled }}
+    {{- if $root.Values.ybc.enabled }}
     - name: "tcp-ybc-port"
       port: {{ $port }}
     {{- end }}
@@ -28,7 +29,7 @@ spec:
   selector:
     statefulset.kubernetes.io/pod-name: {{ $podName | quote }}
     {{- include "yugabyte.appselector" ($appLabelArgs) | indent 4 }}
-  {{- include "yugabyte.ipFamilyConfig" $ | indent 2 }}
+  {{- include "yugabyte.ipFamilyConfig" ($root) | indent 2 }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
We have set `multicluster.createServicePerPod: true` and I got an error during YBUniverse provisioning:
```
No pods even scheduled. Previous step(s) incomplete HELM ERROR: nullError: INSTALLATION FAILED: template: yugabyte/templates/multicluster/service-per-pod.yaml:31:6: executing "yugabyte/templates/multicluster/service-per-pod.yaml" at <include "yugabyte.ipFamilyConfig" .>: error calling include: template: yugabyte/templates/_helpers.tpl:654:14: executing "yugabyte.ipFamilyConfig" at <.Values.ipFamilies>: can't evaluate field Values in type int
```

For some reason the `$` variable does not resolve to the root context. I changed it to use `$root` - following the convention from other templates in this repository.