### PR TITLE
[PLAT-22312] Charts: Point yb.metrics.host at the yugaware service, not 127.0.0.1

### DIFF
--- a/stable/yugaware/templates/configs.yaml
+++ b/stable/yugaware/templates/configs.yaml
@@ -92,7 +92,14 @@ data:
       cloud.requestIdHeader = "{{ .Values.yugaware.cloud.requestIdHeader }}"
       devops.home = /opt/yugabyte/devops
 {{- if .Values.prometheus.enabled }}
-      metrics.host = "{{ eq .Values.ip_version_support "v6_only" | ternary "[::1]" "127.0.0.1" }}"
+      {{- /*
+      The service name, not 127.0.0.1: this address is handed out, not just dialled locally.
+      YBA registers it with the Perf Advisor collector, which scrapes from its own pod and
+      cannot reach a loopback address in this one. Resolving it from inside this pod costs
+      about half a millisecond more than loopback and needs no ip_version_support special
+      case, which an IPv6 literal did.
+      */}}
+      metrics.host = "{{ .Release.Name }}-yugaware-ui"
       metrics.url = "http://"${yb.metrics.host}":9090/api/v1"
       metrics.management.url = "http://"${yb.metrics.host}":9090/-"
       swamper.targetPath = /opt/yugabyte/prometheus/targets


### PR DESCRIPTION
## Summary

YBA registers the embedded Perf Advisor collector with whatever `yb.metrics.url` says. That was
`127.0.0.1:9090` — true for YBA itself, since Prometheus is a sidecar in the yugaware pod, but the
collector runs in the Perf Advisor pod and was being handed an address that points it at itself. It
never reached YBA's Prometheus, so it collected nothing for anomaly detection. Confirmed on a live
deployment: `customer_metadata.metrics_url` was `http://127.0.0.1:9090`, and from inside the Perf
Advisor pod that address is unreachable while the service name answers.

`yb.metrics.url` is handed out, not just dialled locally, so this points `yb.metrics.host` at the
yugaware service — one address that is correct from anywhere in the cluster, for the collector and
for YBA itself. It also drops the `ip_version_support` ternary, which existed only to spell loopback
as `[::1]`.

The service already exposes port 9090, the StatefulSet is single-replica, and Prometheus on that
port is plain HTTP whether or not `tls.enabled`, so one name serves every caller. Prometheus' own
scrape jobs keep dialling `127.0.0.1` — those run inside the pod and are not handed to anyone.

Two things a reviewer should weigh:

- **Hairpin.** YBA now reaches its own Prometheus through a Service rather than loopback. Verified
  working on a live cluster; it is standard kube-proxy behaviour, but it is the new dependency here.
- **Readiness.** If `yugaware.pod.probes.readinessProbe` is enabled (off by default), an unready
  yugaware pod leaves the service endpoints and YBA can no longer reach its own Prometheus. The
  readiness path is YBA's own `/api/app_version`, so when that fails YBA is not serving anyway; the
  real window is the 30s `initialDelaySeconds` at startup.

Deliberately **not** changed: the same three lines in `node_agent_installed_preupgrade_hook.yaml`.
That Job has no Prometheus sidecar and boots the yugaware binary in precheck mode — loopback there
fails fast against nothing, where the service name would let a pre-upgrade check make live calls,
`/-/reload` included, against the running deployment.

No YBA-side change is needed; registration already passes `yb.metrics.url` through verbatim.

## Test Plan

- [x] `helm template` across the affected paths: default → `metrics.host = "myrel-yugaware-ui"` with
      `metrics.url` / `metrics.management.url` deriving from it; `ip_version_support=v6_only` → same
      name, no `[::1]`; `prometheus.enabled=false` → block absent, unchanged.
- [x] `helm lint` clean apart from the pre-existing `policy/v1beta1` PodDisruptionBudget warning.
- [x] Reachability on a live deployment: from the Perf Advisor pod, `127.0.0.1:9090` is unreachable
      and the yugaware service name answers; from the yugaware container both answer, so the
      hairpin path works.
- [x] Latency measured from the yugaware container: 0.7ms via loopback, 1.2ms via the service
      ClusterIP. The rest of a cold request is DNS (~40ms `time_namelookup`), which a pooled JVM
      client resolves once rather than per query.
