### PR TITLE
[PLAT-22235] Charts: Refresh log_cleanup.sh on the volume on every pod start

### DIFF
--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -509,10 +509,8 @@ spec:
                 - "-c"
                 - >
                   mkdir -p /mnt/disk0/yb-data/scripts;
-                  if [ ! -f /mnt/disk0/yb-data/scripts/log_cleanup.sh ]; then
-                    if [ -f /home/yugabyte/bin/log_cleanup.sh ]; then
-                      cp /home/yugabyte/bin/log_cleanup.sh /mnt/disk0/yb-data/scripts;
-                    fi;
+                  if [ -f /home/yugabyte/bin/log_cleanup.sh ]; then
+                    cp -f /home/yugabyte/bin/log_cleanup.sh /mnt/disk0/yb-data/scripts;
                   fi
         {{- if (and (not $storageEphemeral) (not $service.skipHealthChecks)) }}
         {{- if $root.Values.livenessProbe.enabled }}


### PR DESCRIPTION
The DB container's `postStart` hook copied `bin/log_cleanup.sh` from the image to
`<volume>/yb-data/scripts` only when nothing was there yet, so the first copy a universe ever
made stayed forever. The `yb-cleanup` container runs *that* copy, which means a fix to
`log_cleanup.sh` in a newer DB release never reached an existing universe — upgrading the
software changed the image but not the script being run.

This copies it unconditionally, matching what YBA already does on VMs, where the node agent
rewrites `zip_purge_yb_logs.sh` on every configure.

The immediate need is the node health check log: YBA is adding
`metrics/logs/node_health-<date>.log` to `log_cleanup.sh`'s gzip and purge handling
(PLAT-22235), and without this an upgraded universe would keep running the old script and let
that directory grow unbounded.

One consequence worth stating: a hand-edited `log_cleanup.sh` on the volume is now replaced on
the next pod restart.

## Test plan

- `helm template stable/yugabyte` — renders, and the `postStart` hook contains the unconditional `cp -f`
- `helm lint stable/yugabyte` — 1 chart linted, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)