### PR TITLE
Charts: Allow exporting serviceEndpoints services as ServiceExport for MCS

### DIFF
--- a/stable/yugabyte/templates/service-endpoints.yaml
+++ b/stable/yugabyte/templates/service-endpoints.yaml
@@ -84,6 +84,34 @@ spec:
   {{ $key }}: {{ $value | quote }}
   {{- end }}
 ---
+{{- /* Export this endpoint service to the ClusterSet (KEP-1645) */}}
+{{- if $endpoint.exportService }}
+apiVersion: {{ $root.Values.multicluster.mcsApiVersion }}
+kind: ServiceExport
+metadata:
+  name: {{ $serviceName | quote }}
+  namespace: "{{ $root.Release.Namespace }}"
+  {{- if eq $scope "Namespaced" }}
+  annotations:
+    # Keep resource for namespaced services
+    "helm.sh/resource-policy": keep
+  {{- end }}
+  labels:
+    # scope is "Namespaced" or "AZ"
+    scope: {{ $scope }}
+    serviceName: {{ $endpoint.name }}
+    service-type: "endpoint"
+    {{- include "yugabyte.applabel" ($appLabelArgs) | indent 4 }}
+    {{- $exportLabels := include "yugabyte.labels" $root | fromYaml }}
+    # For Namespaced service, remove zone and release name filter
+    {{- if eq $scope "Namespaced" }}
+    {{- $exportLabels = omit $exportLabels "yugabyte.io/zone" "release" }}
+    {{- end }}
+    {{- range $key,$value := $exportLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/yugabyte/tests/test_service_endpoint_export.yaml
+++ b/stable/yugabyte/tests/test_service_endpoint_export.yaml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/quintush/helm-unittest/master/schema/helm-testsuite.json
+suite: serviceEndpoints ServiceExport
+templates:
+- templates/service-endpoints.yaml
+tests:
+- it: no ServiceExport is created by default
+  release:
+    name: yb-demo
+  asserts:
+  - hasDocuments:
+      count: 3
+
+- it: creates a ServiceExport only for the endpoints which opt in
+  release:
+    name: yb-demo
+  set:
+    serviceEndpoints:
+    - name: "yb-master-ui"
+      type: LoadBalancer
+      scope: "AZ"
+      app: "yb-master"
+      exportService: true
+      ports:
+        http-ui: "7000"
+    - name: "yql-service"
+      type: LoadBalancer
+      scope: "AZ"
+      app: "yb-tserver"
+      exportService: false
+      ports:
+        tcp-yql-port: "9042"
+  asserts:
+  - hasDocuments:
+      count: 3
+  - documentIndex: 1
+    isKind:
+      of: ServiceExport
+  - documentIndex: 1
+    equal:
+      path: apiVersion
+      value: multicluster.x-k8s.io/v1alpha1
+  - documentIndex: 1
+    equal:
+      path: metadata.name
+      value: yb-master-ui
+  - documentIndex: 1
+    equal:
+      path: metadata.labels.serviceName
+      value: yb-master-ui
+  - documentIndex: 1
+    equal:
+      path: metadata.labels.scope
+      value: AZ
+
+- it: honours multicluster.mcsApiVersion and the new naming style
+  release:
+    name: yb-demo
+  set:
+    oldNamingStyle: false
+    multicluster.mcsApiVersion: net.gke.io/v1
+    serviceEndpoints:
+    - name: "yb-master-ui"
+      type: LoadBalancer
+      scope: "AZ"
+      app: "yb-master"
+      exportService: true
+      ports:
+        http-ui: "7000"
+  asserts:
+  - hasDocuments:
+      count: 2
+  - documentIndex: 1
+    equal:
+      path: apiVersion
+      value: net.gke.io/v1
+  - documentIndex: 1
+    equal:
+      path: metadata.name
+      value: yb-demo-yugabyte-yb-master-ui
+
+- it: keeps the namespaced ServiceExport on uninstall
+  release:
+    name: yb-demo
+  set:
+    oldNamingStyle: false
+    serviceEndpoints:
+    - name: "yb-tserver-service"
+      type: ClusterIP
+      scope: "Namespaced"
+      app: "yb-tserver"
+      exportService: true
+      ports:
+        tcp-ysql-port: "5433"
+  asserts:
+  - documentIndex: 1
+    isKind:
+      of: ServiceExport
+  - documentIndex: 1
+    equal:
+      path: metadata.annotations["helm.sh/resource-policy"]
+      value: keep
+  - documentIndex: 1
+    equal:
+      path: metadata.name
+      value: namespaced-yb-tserver-service

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -358,6 +358,12 @@ serviceEndpoints:
     loadBalancerIP: ""
     ports:
       http-ui: "7000"
+    ## Set to true to create a ServiceExport (KEP-1645) for this
+    ## service, making it reachable from the other clusters of the
+    ## ClusterSet. Requires the multi-cluster services API to be
+    ## available in the cluster. The apiVersion of the ServiceExport is
+    ## controlled by multicluster.mcsApiVersion.
+    exportService: false
     extraArgs: {}
 
   - name: "yb-tserver-service"
@@ -374,6 +380,12 @@ serviceEndpoints:
       tcp-yql-port: "9042"
       tcp-yedis-port: "6379"
       tcp-ysql-port: "5433"
+    ## Set to true to create a ServiceExport (KEP-1645) for this
+    ## service, making it reachable from the other clusters of the
+    ## ClusterSet. Requires the multi-cluster services API to be
+    ## available in the cluster. The apiVersion of the ServiceExport is
+    ## controlled by multicluster.mcsApiVersion.
+    exportService: false
     extraArgs: {}
 
   - name: "yugabyted-ui-service"
@@ -389,6 +401,12 @@ serviceEndpoints:
     sessionAffinity: ClientIP
     ports:
       yugabyted-ui: "15433"
+    ## Set to true to create a ServiceExport (KEP-1645) for this
+    ## service, making it reachable from the other clusters of the
+    ## ClusterSet. Requires the multi-cluster services API to be
+    ## available in the cluster. The apiVersion of the ServiceExport is
+    ## controlled by multicluster.mcsApiVersion.
+    exportService: false
     extraArgs: {}
 
 Services:


### PR DESCRIPTION
## Why

This is needed for the **namespace sameness** case of MCS, where clusterset-based DNS has to be able to reach all the pods across the clusters.

Today `multicluster.createServiceExports` only exports the headless `yb-masters` / `yb-tservers` services. The services defined under `serviceEndpoints` (`yb-master-ui`, `yb-tserver-service`, `yugabyted-ui-service`, ...) stay cluster-local, so they are not resolvable over `*.svc.clusterset.local` from the peer clusters of the clusterset. This adds an opt-in way to export them too.

## What

A per-endpoint `exportService` flag on `serviceEndpoints`, **defaulting to `false`** so existing installs are unaffected:

```yaml
serviceEndpoints:
  - name: "yb-tserver-service"
    type: ClusterIP
    scope: "Namespaced"
    app: "yb-tserver"
    ## Set to true to create a ServiceExport (KEP-1645) for this
    ## service, making it reachable from the other clusters of the
    ## ClusterSet.
    exportService: true
    ports:
      tcp-ysql-port: "5433"
```

When the flag is set, a `ServiceExport` is emitted right after that endpoint's `Service` in `templates/service-endpoints.yaml`:

- It sits inside the same render guards, so it inherits the existing `enableLoadBalancer`, app-match, naming-style, scope and `yugabyted-ui` conditions — no export is ever created without its Service.
- It reuses the same `$serviceName`, so the export always matches the name of the Service it belongs to, under either naming style.
- It carries the same labels as the Service, and gets `helm.sh/resource-policy: keep` for `Namespaced` scope, matching what the Service already does.
- `apiVersion` comes from the existing `multicluster.mcsApiVersion`, so `net.gke.io/v1` works for GKE MCS.
- This is independent of `multicluster.createServiceExports`, which keeps exporting only the headless services.

Endpoint-level `annotations` are deliberately **not** copied onto the export — those are load-balancer annotations and carry no meaning on a `ServiceExport`.

## Testing

New suite `stable/yugabyte/tests/test_service_endpoint_export.yaml` covers: nothing exported by default, only opted-in endpoints exported, `mcsApiVersion` + new-naming-style naming, and the namespaced `keep` annotation.

```
$ cd stable/yugabyte && helm unittest -f "tests/test_*.yaml" .
Test Suites: 8 passed, 8 total
Tests:       57 passed, 57 total
```

`helm lint` is clean apart from the two pre-existing `policy/v1beta1` PodDisruptionBudget deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
