### PR TITLE
[BACKPORT 2026.1][PLAT-21851] Charts: Increase tserver shared memory size and add a precheck

### DIFF
--- a/stable/yugabyte/templates/_helpers.tpl
+++ b/stable/yugabyte/templates/_helpers.tpl
@@ -37,7 +37,9 @@ component: {{ .Values.Component | quote }}
 {{- else }}
 {{- $filteredLabels = omit $filteredLabels "heritage" "release" "chart" "component" "app" "app.kubernetes.io/name" }}
 {{- end }}
+{{- if $filteredLabels }}
 {{ toYaml $filteredLabels }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/stable/yugabyte/templates/service.yaml
+++ b/stable/yugabyte/templates/service.yaml
@@ -600,7 +600,15 @@ spec:
           {{- $preCommands := ( (eq $service.name "yb-masters") | ternary $root.Values.master.advanced.preCommands $root.Values.tserver.advanced.preCommands ) }} {{- with $preCommands }} {{ . | nindent 12 }} {{- end }}
           {{- if and (not $root.Values.preflight.skipUlimit) (not $root.Values.preflight.skipAll) }}
             if [ -f /home/yugabyte/tools/k8s_preflight.py ]; then
+              {{- if and (eq $service.name "yb-tservers") (not $root.Values.preflight.skipShm) $root.Values.tserver.shm $root.Values.tserver.shm.enabled }}
+              if /home/yugabyte/tools/k8s_preflight.py all --help 2>/dev/null | grep -q -- '--check_shm'; then
+                /home/yugabyte/tools/k8s_preflight.py all --check_shm
+              else
+                /home/yugabyte/tools/k8s_preflight.py all
+              fi
+              {{- else }}
               /home/yugabyte/tools/k8s_preflight.py all
+              {{- end }}
             fi && \
           {{- end }}
           {{- if (and (not $storageEphemeral) (not $root.Values.preflight.skipAll)) }}
@@ -673,6 +681,10 @@ spec:
             mountPath: /tmp
           - name: tserver-gflags
             mountPath: /opt/tserver/conf
+          {{- if and $root.Values.tserver.shm $root.Values.tserver.shm.enabled }}
+          - name: yugabyte-dshm
+            mountPath: /dev/shm
+          {{- end }}
           {{- else if (eq $service.name "yb-masters") }}
           - name: master-gflags
             mountPath: /opt/master/conf
@@ -951,6 +963,12 @@ spec:
         {{- end }}
         - name: tserver-tmp
           emptyDir: {}
+        {{- if and $root.Values.tserver.shm $root.Values.tserver.shm.enabled }}
+        - name: yugabyte-dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ $root.Values.tserver.shm.sizeLimit | quote }}
+        {{- end }}
         {{- end }}
         {{- if $root.Values.tls.enabled }}
         {{- if $root.Values.tls.certManager.enabled }}

--- a/stable/yugabyte/tests/test_labels.yaml
+++ b/stable/yugabyte/tests/test_labels.yaml
@@ -529,36 +529,26 @@ tests:
       app.kubernetes.io/name: overridden-name
       release: overridden-release
       environment: production
+  documentSelector:
+    path: kind
+    value: StatefulSet
   asserts:
-  # Verify StatefulSet exists at documentIndex 2
-  - matchRegex:
-      path: kind
-      pattern: StatefulSet
-      documentIndex: 2
   # Selector should use service-specific app label, not overridden value
   - equal:
       path: spec.selector.matchLabels['app.kubernetes.io/name']
       value: yb-master
-      documentIndex: 2
   - exists:
       path: spec.selector.matchLabels.release
-      documentIndex: 2
   # Pod template should also have service-specific app label
   - equal:
       path: spec.template.metadata.labels['app.kubernetes.io/name']
       value: yb-master
-      documentIndex: 2
   - exists:
       path: spec.template.metadata.labels.release
-      documentIndex: 2
   # Custom labels should still be present
-  - exists:
-      path: spec.template.metadata.labels.environment
-      documentIndex: 2
   - equal:
       path: spec.template.metadata.labels.environment
       value: production
-      documentIndex: 2
 
 # Test custom labels on multiple object types
 - it: custom labels appear on ConfigMap

--- a/stable/yugabyte/tests/test_tserver_shm.yaml
+++ b/stable/yugabyte/tests/test_tserver_shm.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/quintush/helm-unittest/master/schema/helm-testsuite.json
+suite: tserver /dev/shm Memory emptyDir
+tests:
+- it: mounts yugabyte-dshm on tserver by default
+  template: templates/service.yaml
+  set:
+    oldNamingStyle: true
+  documentSelector:
+    path: metadata.name
+    value: yb-tserver
+  asserts:
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: yugabyte-dshm
+        emptyDir:
+          medium: Memory
+          sizeLimit: "256Mi"
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: yugabyte-dshm
+        mountPath: /dev/shm
+
+- it: does not mount yugabyte-dshm on master
+  template: templates/service.yaml
+  set:
+    oldNamingStyle: true
+  documentSelector:
+    path: metadata.name
+    value: yb-master
+  asserts:
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: yugabyte-dshm
+
+- it: omits yugabyte-dshm when tserver.shm.enabled is false
+  template: templates/service.yaml
+  set:
+    oldNamingStyle: true
+    tserver.shm.enabled: false
+  documentSelector:
+    path: metadata.name
+    value: yb-tserver
+  asserts:
+  - notContains:
+      path: spec.template.spec.volumes
+      content:
+        name: yugabyte-dshm

--- a/stable/yugabyte/values.yaml
+++ b/stable/yugabyte/values.yaml
@@ -767,6 +767,14 @@ tserver:
   #   path: /home/yugabyte/nfs-backup
   extraVolumeMounts: []
 
+  ## Container /dev/shm (tmpfs). Kubernetes defaults this to 64Mi; PG-TServer
+  ## shared memory (big_shared_memory_allocated_limit) can allocate up to 128Mi.
+  ## Memory emptyDir counts against the pod memory limit. Disable if you already
+  ## mount /dev/shm via extraVolumes.
+  shm:
+    enabled: true
+    sizeLimit: 256Mi
+
   ## Set service account for tserver DB pods. The service account
   ## should exist in the namespace where the tserver DB pods are brought up.
   serviceAccount: ""
@@ -864,6 +872,10 @@ preflight:
   ## Set to true to skip ulimit verification
   ## SkipAll has higher priority
   skipUlimit: false
+
+  ## Set to true to skip tserver /dev/shm size verification
+  ## SkipAll has higher priority. Only applied when tserver.shm.enabled is true.
+  skipShm: false
 
 ## Liveness Probe configuration for both master and tserver pods
 livenessProbe:


### PR DESCRIPTION
## Summary
Increase the tserver shared memory limit and call the precheck added during the tserver startup script.

Original commit: 9ee5924cbba21edef5f5d1bc969526e28ecd53f2 / #222

## Test plan
- Cherry-pick of https://github.com/yugabyte/charts/pull/222 onto `2026.1` applied cleanly.
